### PR TITLE
Vsix packaging

### DIFF
--- a/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
+++ b/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
@@ -45,7 +45,6 @@ Expected output (order may vary):
 ```text
 README.md
 package.json
-LICENSE
 CHANGELOG.md
 out/backendRunner.js
 out/contracts.js
@@ -63,10 +62,10 @@ If you see `src/**`, `**/*.ts`, `out/test/**`, or `node_modules/**` in the list,
 npx --yes @vscode/vsce package
 ```
 
-The `vscode:prepublish` script compiles the TypeScript first, then `vsce` writes the artifact. Expected result:
+The `vscode:prepublish` script compiles the TypeScript first, then `vsce` writes the artifact. `vsce` prints a harmless `LICENSE ... not found` warning — the extension is licensed via the `"license": "MIT"` field in `package.json` and the repository-root [LICENSE](../../LICENSE) covers it. Expected result:
 
 ```text
-DONE  Packaged: .../mrd-viz-0.0.1.vsix (12 files, ~18 KB)
+DONE  Packaged: .../mrd-viz-0.0.1.vsix (11 files, ~18 KB)
 ```
 
 The `.vsix` is git-ignored (see the repo `.gitignore`) and should **not** be committed; treat it as a build artifact (e.g. attach it to a GitHub Release).

--- a/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
+++ b/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
@@ -94,9 +94,71 @@ ismrmrd.mrd-viz@0.0.1
 
 You can also install from the UI: **Extensions view → Views and More Actions (…) → Install from VSIX…**.
 
-## 6. Use It
+## 6. Set Up the Backend (Required to Open Files)
 
-Open any local `.mrd` file (double-click, or **MRD Viz: Open File** from the Command Palette). The extension needs the `mrd_viz` Python backend available — configure `mrdViz.pythonPath`, or rely on the local `mrd-viz/backend/.venv` fallback. See sections 2–5 of the [Official Extension Development Runbook](OFFICIAL_EXT_DEV_RUNBOOK.md) for backend setup and generating test `.mrd` files.
+Installing the VSIX makes the extension available in every window, but rendering `.mrd` files needs the `mrd_viz` Python backend on the machine. The repo-relative `.venv` auto-detection only works when running from source (the F5 dev host) — an **installed** extension must be pointed at the interpreter explicitly via `mrdViz.pythonPath`.
+
+You only need **steps 1–3** of the [Official Extension Development Runbook](OFFICIAL_EXT_DEV_RUNBOOK.md); they are reproduced here for convenience.
+
+### 6a. Create the backend virtual environment (Python 3.12)
+
+Windows PowerShell:
+
+```powershell
+$repoRoot = git rev-parse --show-toplevel
+$backendRoot = Join-Path $repoRoot "mrd-viz/backend"
+Set-Location $backendRoot
+py -3.12 -m venv .venv
+$python = Join-Path $backendRoot ".venv/Scripts/python.exe"
+& $python -m pip install --upgrade pip
+& $python -m pip install -e .
+```
+
+Linux / macOS Bash:
+
+```bash
+repo_root=$(git rev-parse --show-toplevel)
+backend_root="$repo_root/mrd-viz/backend"
+cd "$backend_root"
+python3.12 -m venv .venv
+./.venv/bin/python -m pip install --upgrade pip
+./.venv/bin/python -m pip install -e .
+```
+
+### 6b. Confirm the interpreter path
+
+Windows PowerShell:
+
+```powershell
+& $python -c "import sys, mrd_viz; print(sys.executable)"
+```
+
+Linux / macOS Bash:
+
+```bash
+./.venv/bin/python -c "import sys, mrd_viz; print(sys.executable)"
+```
+
+The printed path is the value you need next:
+
+- Windows: `<repo-root>\mrd-viz\backend\.venv\Scripts\python.exe`
+- Linux / macOS: `<repo-root>/mrd-viz/backend/.venv/bin/python`
+
+### 6c. Point the extension at that interpreter
+
+Set `mrdViz.pythonPath` to the path from 6b — via **Settings → search "mrdViz: Python Path"**, or in `settings.json`:
+
+```json
+{
+  "mrdViz.pythonPath": "<repo-root>/mrd-viz/backend/.venv/bin/python"
+}
+```
+
+> **Why set this explicitly?** If `mrdViz.pythonPath` is empty, the extension falls back to a bare `python` on `PATH`. On machines that only have `python3` (common on Linux/macOS), that lookup fails and you get a backend error even though Python is installed. Pointing `mrdViz.pythonPath` at the venv interpreter avoids the `python` vs `python3` ambiguity entirely.
+
+### 6d. Open a file
+
+Open any local `.mrd` file (double-click, or **MRD Viz: Open File** from the Command Palette). To generate test `.mrd` files, see section 4 of the [Official Extension Development Runbook](OFFICIAL_EXT_DEV_RUNBOOK.md).
 
 ## 7. Update or Uninstall
 
@@ -116,5 +178,5 @@ code --uninstall-extension ismrmrd.mrd-viz
 ## Notes
 
 - **Publisher / icon:** `publisher` is set to `ismrmrd` so packaging succeeds; an `icon` is optional (only a warning). Both matter only when publishing to the Marketplace, which is out of scope for local installs.
-- **Backend requirement:** installing the VSIX makes the extension available everywhere, but rendering still requires the `mrd_viz` Python backend on the machine. Distributing the backend to end users is tracked separately.
+- **Backend requirement:** installing the VSIX makes the extension available everywhere, but rendering requires the `mrd_viz` Python backend and `mrdViz.pythonPath` pointed at its interpreter (section 6). Distributing/provisioning the backend automatically is tracked separately.
 - **Relation to publishing:** to later publish to the Marketplace, register the `ismrmrd` publisher and run `vsce publish`; the packaging config here (`.vscodeignore`, manifest metadata) is the same foundation.

--- a/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
+++ b/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
@@ -1,0 +1,121 @@
+# Packaging & Local Install Runbook (VSIX)
+
+Use this runbook to package the MRD Viz extension into an installable `.vsix` and install it into a normal VS Code instance — so MRD Viz works in **every** VS Code window without launching an Extension Development Host (F5).
+
+This is the distribution counterpart to the [Official Extension Development Runbook](OFFICIAL_EXT_DEV_RUNBOOK.md). Use that runbook to set up the backend and generate test `.mrd` files; use this one to build and install the extension.
+
+> A `.vsix` is the standard way to distribute an extension **without** publishing to the Marketplace. Publishing (`vsce publish`) is a later, separate step that requires a registered publisher and is not covered here.
+
+## 1. Open a Shell at the Extension Folder
+
+Windows PowerShell:
+
+```powershell
+$repoRoot = git rev-parse --show-toplevel
+Set-Location (Join-Path $repoRoot "mrd-viz/extension/mrd-viz")
+```
+
+Linux / macOS Bash:
+
+```bash
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root/mrd-viz/extension/mrd-viz"
+```
+
+## 2. Install Extension Dependencies
+
+The build (invoked automatically during packaging) needs the dev dependencies present.
+
+```bash
+npm ci
+```
+
+Expected result: dependencies install and `npm audit` reports no vulnerabilities.
+
+## 3. Dry Run — List the Files That Would Be Packaged
+
+Before building, confirm the `.vsix` will contain only the compiled runtime and metadata — no source, tests, or `node_modules`.
+
+```bash
+npx --yes @vscode/vsce ls
+```
+
+Expected output (order may vary):
+
+```text
+README.md
+package.json
+LICENSE
+CHANGELOG.md
+out/backendRunner.js
+out/contracts.js
+out/extension.js
+out/mrdEditorProvider.js
+out/viewerController.js
+out/webviewHtml.js
+```
+
+If you see `src/**`, `**/*.ts`, `out/test/**`, or `node_modules/**` in the list, fix `.vscodeignore` before packaging.
+
+## 4. Package the Extension
+
+```bash
+npx --yes @vscode/vsce package
+```
+
+The `vscode:prepublish` script compiles the TypeScript first, then `vsce` writes the artifact. Expected result:
+
+```text
+DONE  Packaged: .../mrd-viz-0.0.1.vsix (12 files, ~18 KB)
+```
+
+The `.vsix` is git-ignored (see the repo `.gitignore`) and should **not** be committed; treat it as a build artifact (e.g. attach it to a GitHub Release).
+
+## 5. Install the VSIX Locally
+
+Windows PowerShell:
+
+```powershell
+code --install-extension mrd-viz-0.0.1.vsix
+code --list-extensions --show-versions | Select-String "mrd-viz"
+```
+
+Linux / macOS Bash:
+
+```bash
+code --install-extension mrd-viz-0.0.1.vsix
+code --list-extensions --show-versions | grep mrd-viz
+```
+
+Expected output:
+
+```text
+ismrmrd.mrd-viz@0.0.1
+```
+
+You can also install from the UI: **Extensions view → Views and More Actions (…) → Install from VSIX…**.
+
+## 6. Use It
+
+Open any local `.mrd` file (double-click, or **MRD Viz: Open File** from the Command Palette). The extension needs the `mrd_viz` Python backend available — configure `mrdViz.pythonPath`, or rely on the local `mrd-viz/backend/.venv` fallback. See sections 2–5 of the [Official Extension Development Runbook](OFFICIAL_EXT_DEV_RUNBOOK.md) for backend setup and generating test `.mrd` files.
+
+## 7. Update or Uninstall
+
+Reinstalling a new build over an existing install:
+
+```bash
+npx --yes @vscode/vsce package
+code --install-extension mrd-viz-0.0.1.vsix --force
+```
+
+Uninstall:
+
+```bash
+code --uninstall-extension ismrmrd.mrd-viz
+```
+
+## Notes
+
+- **Publisher / icon:** `publisher` is set to `ismrmrd` so packaging succeeds; an `icon` is optional (only a warning). Both matter only when publishing to the Marketplace, which is out of scope for local installs.
+- **Backend requirement:** installing the VSIX makes the extension available everywhere, but rendering still requires the `mrd_viz` Python backend on the machine. Distributing the backend to end users is tracked separately.
+- **Relation to publishing:** to later publish to the Marketplace, register the `ismrmrd` publisher and run `vsce publish`; the packaging config here (`.vscodeignore`, manifest metadata) is the same foundation.

--- a/mrd-viz/extension/mrd-viz/.vscodeignore
+++ b/mrd-viz/extension/mrd-viz/.vscodeignore
@@ -1,6 +1,7 @@
 .vscode/**
 .vscode-test/**
 src/**
+out/test/**
 .gitignore
 .yarnrc
 vsc-extension-quickstart.md
@@ -9,3 +10,4 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 **/.vscode-test.*
+package-lock.json

--- a/mrd-viz/extension/mrd-viz/LICENSE
+++ b/mrd-viz/extension/mrd-viz/LICENSE
@@ -1,0 +1,8 @@
+The MIT License (MIT)
+Copyright © 2024 ISMRMRD Steering Committee
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/mrd-viz/extension/mrd-viz/LICENSE
+++ b/mrd-viz/extension/mrd-viz/LICENSE
@@ -1,8 +1,0 @@
-The MIT License (MIT)
-Copyright © 2024 ISMRMRD Steering Committee
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/mrd-viz/extension/mrd-viz/README.md
+++ b/mrd-viz/extension/mrd-viz/README.md
@@ -1,71 +1,40 @@
-# mrd-viz README
+# MRD Viz
 
-This is the README for your extension "mrd-viz". After writing up a brief description, we recommend including the following sections.
+A Visual Studio Code extension for inspecting [MRD](https://github.com/ismrmrd/mrd) (Magnetic Resonance Data) files directly in the editor. Open a `.mrd` file to view a thumbnail mosaic of its images alongside acquisition, waveform, and header metadata.
 
 ## Features
 
-Describe specific features of your extension including screenshots of your extension in action. Image paths are relative to this README file.
-
-For example if there is an image subfolder under your extension project workspace:
-
-\!\[feature X\]\(images/feature-x.png\)
-
-> Tip: Many popular extensions utilize animations. This is an excellent way to show off your extension! We recommend short, focused animations that are easy to follow.
+- Opens `.mrd` files in a custom editor (thumbnail mosaic + metadata panels).
+- Select a tile to load its full-resolution image on demand.
+- Browse image, acquisition, waveform, and raw-stream metadata, including a raw JSON view.
 
 ## Requirements
 
-If you have any requirements or dependencies, add a section describing those and how to install and configure them.
+MRD Viz relies on a Python backend (the `mrd_viz` package) to read `.mrd` files. You need:
+
+- Python 3.12
+- The `mrd_viz` backend installed into an environment the extension can find.
+
+Point the extension at the interpreter with the `mrdViz.pythonPath` setting (see below). During local development the extension also auto-detects a virtual environment at `mrd-viz/backend/.venv`.
 
 ## Extension Settings
 
-Include if your extension adds any VS Code settings through the `contributes.configuration` extension point.
-
-For example:
-
 This extension contributes the following settings:
 
-* `myExtension.enable`: Enable/disable this extension.
-* `myExtension.thing`: Set to `blah` to do something.
+- `mrdViz.pythonPath`: Python executable used to run `python -m mrd_viz.cli`. Set this to the backend environment's interpreter.
+- `mrdViz.maxThumbnails`: Maximum number of image thumbnails requested for the initial view (default `128`).
+- `mrdViz.backendTimeoutMs`: Timeout in milliseconds for a single backend process (default `30000`).
+
+## Commands
+
+- `MRD Viz: Open File` — open the selected or picked `.mrd` file in MRD Viz.
 
 ## Known Issues
 
-Calling out known issues can help limit users opening duplicate issues against your extension.
+- Non-`.mrd` files and non-`file://` resources are rejected with a warning; only local `.mrd` files are supported.
 
 ## Release Notes
 
-Users appreciate release notes as you update your extension.
+### 0.0.1
 
-### 1.0.0
-
-Initial release of ...
-
-### 1.0.1
-
-Fixed issue #.
-
-### 1.1.0
-
-Added features X, Y, and Z.
-
----
-
-## Following extension guidelines
-
-Ensure that you've read through the extensions guidelines and follow the best practices for creating your extension.
-
-* [Extension Guidelines](https://code.visualstudio.com/api/references/extension-guidelines)
-
-## Working with Markdown
-
-You can author your README using Visual Studio Code. Here are some useful editor keyboard shortcuts:
-
-* Split the editor (`Cmd+\` on macOS or `Ctrl+\` on Windows and Linux).
-* Toggle preview (`Shift+Cmd+V` on macOS or `Shift+Ctrl+V` on Windows and Linux).
-* Press `Ctrl+Space` (Windows, Linux, macOS) to see a list of Markdown snippets.
-
-## For more information
-
-* [Visual Studio Code's Markdown Support](http://code.visualstudio.com/docs/languages/markdown)
-* [Markdown Syntax Reference](https://help.github.com/articles/markdown-basics/)
-
-**Enjoy!**
+Initial preview: custom editor, thumbnail mosaic, on-demand full-resolution images, and metadata panels.

--- a/mrd-viz/extension/mrd-viz/package.json
+++ b/mrd-viz/extension/mrd-viz/package.json
@@ -3,6 +3,12 @@
   "displayName": "MRD Viz",
   "description": "MRD file viewer for VS Code",
   "version": "0.0.1",
+  "publisher": "ismrmrd",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ismrmrd/mrd.git"
+  },
   "engines": {
     "vscode": "^1.120.0"
   },


### PR DESCRIPTION
VSIX local install is the intermediate step, installing hte extension into the uesr's normal VS Code so that it persists and works in every window. 

`docs/PACKAGING_AND_INSTALL_RUNBOOK.md` outlines the steps walking through prereqs, dry run, package, local install, update/uninstall. 

Rendering still requires the mrd_viz python backend on the machine (mrdviz.pythonpath or venv fallback), so on a fresh machine it will hit an error editor. distributing backend remains in-progress. 

currently ismrmrd publisher is a placeholder to statisfy local packaging, but an eventual marketplace publish would require a registered publisher ID.

most of the changes are simply packacing setup to satisfy vsce requirements.