### PR TITLE
Mrd viz devcontainer

### DIFF
--- a/.devcontainer/mrd-viz/devcontainer.json
+++ b/.devcontainer/mrd-viz/devcontainer.json
@@ -6,11 +6,13 @@
   "name": "MRD Viz extension",
   "image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {},
     "ghcr.io/devcontainers/features/azure-cli:1": {}
   },
-  // Installs the `just` and `azcopy` CLIs. Project provisioning (backend + the
-  // MRD Viz extension) is a one-time `just container-setup` you run afterwards.
+  // postCreate installs Node.js (from nodejs.org), plus the `just` and `azcopy`
+  // CLIs. Node is installed here rather than via the devcontainer `node` feature
+  // because that feature pulls pnpm from the public npm registry at build time,
+  // which is blocked on some corporate networks. Project provisioning (backend +
+  // the MRD Viz extension) is a one-time `just container-setup` you run afterwards.
   "postCreateCommand": "bash .devcontainer/mrd-viz/postCreate.sh",
   "customizations": {
     "vscode": {

--- a/.devcontainer/mrd-viz/devcontainer.json
+++ b/.devcontainer/mrd-viz/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  // Lightweight, extension-specific dev container for MRD Viz (Scenario B).
+  // The other config, ".devcontainer/devcontainer.json" ("mrd"), is the full
+  // repo toolchain (conda + MATLAB + C++) and is a poor fit for just viewing
+  // .mrd files, so this pins Python 3.12 (matching the backend) and stays minimal.
+  "name": "MRD Viz extension",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/azure-cli:1": {}
+  },
+  // Installs the `just` and `azcopy` CLIs. Project provisioning (backend + the
+  // MRD Viz extension) is a one-time `just container-setup` you run afterwards.
+  "postCreateCommand": "bash .devcontainer/mrd-viz/postCreate.sh",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        // `just container-setup` creates this venv; pointing the extension at it
+        // explicitly avoids the installed-VSIX discovery gap and the python/python3
+        // PATH ambiguity.
+        "mrdViz.pythonPath": "/home/vscode/.venvs/mrd-viz/bin/python",
+        "python.defaultInterpreterPath": "/home/vscode/.venvs/mrd-viz/bin/python"
+      },
+      "extensions": [
+        "ms-python.python"
+      ]
+    }
+  }
+}

--- a/.devcontainer/mrd-viz/postCreate.sh
+++ b/.devcontainer/mrd-viz/postCreate.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# postCreate for the MRD Viz dev container.
+# Installs the generic CLI tools the workflow needs. Project provisioning
+# (backend + extension) is a one-time `just container-setup` run by the user.
+set -euo pipefail
+
+# just: task runner used by `just container-setup`.
+if ! command -v just >/dev/null 2>&1; then
+	echo ">> Installing just"
+	curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+fi
+
+# azcopy: used to pull .mrd data from Azure storage.
+if ! command -v azcopy >/dev/null 2>&1; then
+	echo ">> Installing azcopy"
+	curl -sSL https://aka.ms/downloadazcopy-v10-linux -o /tmp/azcopy.tar.gz
+	tar -xzf /tmp/azcopy.tar.gz -C /tmp
+	sudo cp /tmp/azcopy_linux_amd64_*/azcopy /usr/local/bin/azcopy
+	sudo chmod +x /usr/local/bin/azcopy
+	rm -rf /tmp/azcopy.tar.gz /tmp/azcopy_linux_amd64_*
+fi
+
+cat <<'EOF'
+
+============================================================
+ MRD Viz dev container is ready.
+
+ Next step (run once):
+     cd mrd-viz && just container-setup
+
+ That creates the backend virtualenv, installs mrd_viz, and
+ builds + installs the MRD Viz extension in this window.
+============================================================
+EOF

--- a/.devcontainer/mrd-viz/postCreate.sh
+++ b/.devcontainer/mrd-viz/postCreate.sh
@@ -4,13 +4,21 @@
 # (backend + extension) is a one-time `just container-setup` run by the user.
 set -euo pipefail
 
+# Resolve the container architecture so the Node and azcopy downloads match it.
+arch="$(uname -m)"
+case "$arch" in
+	x86_64)        node_arch="x64";   azcopy_url="https://aka.ms/downloadazcopy-v10-linux";       azcopy_glob="azcopy_linux_amd64_*" ;;
+	aarch64|arm64) node_arch="arm64"; azcopy_url="https://aka.ms/downloadazcopy-v10-linux-arm64"; azcopy_glob="azcopy_linux_arm64_*" ;;
+	*) echo ">> Unsupported architecture: $arch" >&2; exit 1 ;;
+esac
+
 # Node.js (from nodejs.org, which is reachable even where the public npm registry
 # is blocked). Installed here instead of the devcontainer `node` feature, which
 # pulls pnpm from the public npm registry at build time. Node bundles npm.
 if ! command -v node >/dev/null 2>&1; then
 	echo ">> Installing Node.js"
 	node_version="v24.18.0"
-	curl -fsSL "https://nodejs.org/dist/${node_version}/node-${node_version}-linux-x64.tar.xz" -o /tmp/node.tar.xz
+	curl -fsSL "https://nodejs.org/dist/${node_version}/node-${node_version}-linux-${node_arch}.tar.xz" -o /tmp/node.tar.xz
 	sudo tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1
 	rm -f /tmp/node.tar.xz
 fi
@@ -18,17 +26,19 @@ fi
 # just: task runner used by `just container-setup`.
 if ! command -v just >/dev/null 2>&1; then
 	echo ">> Installing just"
-	curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
+	curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh -o /tmp/just-install.sh
+	sudo bash /tmp/just-install.sh --to /usr/local/bin
+	rm -f /tmp/just-install.sh
 fi
 
 # azcopy: used to pull .mrd data from Azure storage.
 if ! command -v azcopy >/dev/null 2>&1; then
 	echo ">> Installing azcopy"
-	curl -sSL https://aka.ms/downloadazcopy-v10-linux -o /tmp/azcopy.tar.gz
+	curl -sSL "$azcopy_url" -o /tmp/azcopy.tar.gz
 	tar -xzf /tmp/azcopy.tar.gz -C /tmp
-	sudo cp /tmp/azcopy_linux_amd64_*/azcopy /usr/local/bin/azcopy
+	sudo cp /tmp/${azcopy_glob}/azcopy /usr/local/bin/azcopy
 	sudo chmod +x /usr/local/bin/azcopy
-	rm -rf /tmp/azcopy.tar.gz /tmp/azcopy_linux_amd64_*
+	rm -rf /tmp/azcopy.tar.gz /tmp/${azcopy_glob}
 fi
 
 cat <<'EOF'

--- a/.devcontainer/mrd-viz/postCreate.sh
+++ b/.devcontainer/mrd-viz/postCreate.sh
@@ -47,7 +47,7 @@ cat <<'EOF'
  MRD Viz dev container is ready.
 
  Next step (run once):
-     cd mrd-viz && just container-setup
+     just mrd-viz-container-setup
 
  That creates the backend virtualenv, installs mrd_viz, and
  builds + installs the MRD Viz extension in this window.

--- a/.devcontainer/mrd-viz/postCreate.sh
+++ b/.devcontainer/mrd-viz/postCreate.sh
@@ -4,6 +4,17 @@
 # (backend + extension) is a one-time `just container-setup` run by the user.
 set -euo pipefail
 
+# Node.js (from nodejs.org, which is reachable even where the public npm registry
+# is blocked). Installed here instead of the devcontainer `node` feature, which
+# pulls pnpm from the public npm registry at build time. Node bundles npm.
+if ! command -v node >/dev/null 2>&1; then
+	echo ">> Installing Node.js"
+	node_version="v24.18.0"
+	curl -fsSL "https://nodejs.org/dist/${node_version}/node-${node_version}-linux-x64.tar.xz" -o /tmp/node.tar.xz
+	sudo tar -xJf /tmp/node.tar.xz -C /usr/local --strip-components=1
+	rm -f /tmp/node.tar.xz
+fi
+
 # just: task runner used by `just container-setup`.
 if ! command -v just >/dev/null 2>&1; then
 	echo ">> Installing just"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts and justfiles run inside Linux dev containers; keep them LF
+# so bash/just don't choke on CR characters even when edited on Windows.
+*.sh text eol=lf
+justfile text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ cpp/build/
 
 # Local dev-container data landing zone (e.g. azcopy pulls of large .mrd files)
 /data/
+mrd-viz/data/
 
 *.bin
 *.png

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ cpp/build/
 .vscode/
 *.ipynb
 
+# Local dev-container data landing zone (e.g. azcopy pulls of large .mrd files)
+/data/
+
 *.bin
 *.png
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@ cpp/build/
 *.ipynb
 
 # Local dev-container data landing zone (e.g. azcopy pulls of large .mrd files)
-/data/
 mrd-viz/data/
 
 *.bin

--- a/justfile
+++ b/justfile
@@ -105,3 +105,8 @@ validate-with-no-changes: test
 
 @test-docker-images:
     ./docker/test-docker-images.sh
+
+# Provision the MRD Viz dev container (delegates into mrd-viz/justfile so you
+# don't have to `cd mrd-viz` first).
+@mrd-viz-container-setup:
+    cd mrd-viz && just container-setup

--- a/mrd-viz/.gitignore
+++ b/mrd-viz/.gitignore
@@ -5,4 +5,6 @@ backend/src/**/__pycache__/
 extension/mrd-viz/node_modules/
 extension/mrd-viz/out/
 extension/mrd-viz/.vscode-test/
+# Local npm registry override (e.g. a corporate feed on restricted networks).
+extension/mrd-viz/.npmrc
 *.vsix

--- a/mrd-viz/docs/DEVCONTAINER.md
+++ b/mrd-viz/docs/DEVCONTAINER.md
@@ -19,19 +19,18 @@ Run MRD Viz inside a reproducible dev container: Python 3.12 + the `mrd_viz` bac
 From the integrated terminal (now connected to the container):
 
 ```bash
-cd mrd-viz
-just container-setup
+just mrd-viz-container-setup
 ```
 
 This creates a backend virtualenv at `~/.venvs/mrd-viz`, installs the `mrd_viz` backend into it, builds the extension `.vsix`, and installs it in this window. `mrdViz.pythonPath` is already pointed at that venv, so no further configuration is needed. Reload the window if the extension does not activate immediately.
 
 ## 3. Pull `.mrd` data from Azure
 
-Authenticate and copy files into the repo-root `data/` directory (git-ignored):
+Authenticate and copy files into the `mrd-viz/data/` directory (git-ignored):
 
 ```bash
 az login            # or use a SAS URL
-azcopy copy "<source>" /workspaces/mrd/data --recursive
+azcopy copy "<source>" /workspaces/mrd/mrd-viz/data --recursive
 ```
 
 ## 4. Open a file
@@ -40,7 +39,7 @@ Double-click any `.mrd` file, or run **MRD Viz: Open File** from the Command Pal
 
 ## Restricted / corporate networks
 
-Some corporate networks block direct access to the **public npm registry** (`registry.npmjs.org`) and require an internal mirror instead. Symptom: the container build or `just container-setup` fails with an `npm` **TLS handshake failure** to `registry.npmjs.org`. (PyPI is typically unaffected, so the backend install still works.)
+Some corporate networks block direct access to the **public npm registry** (`registry.npmjs.org`) and require an internal mirror instead. Symptom: the container build or `just mrd-viz-container-setup` fails with an `npm` **TLS handshake failure** to `registry.npmjs.org`. (PyPI is typically unaffected, so the backend install still works.)
 
 To fix it, point the container's npm at your organization's feed with a **git-ignored** `.npmrc`:
 
@@ -51,7 +50,7 @@ To fix it, point the container's npm at your organization's feed with a **git-ig
    registry=https://your-org-feed.example/npm/
    ```
 
-3. Run `just container-setup` again.
+3. Run `just mrd-viz-container-setup` again.
 
 If your feed requires authentication, add the appropriate `_authToken`/credential-provider lines (same as your host `.npmrc`). This file is git-ignored so the internal URL is never committed.
 

--- a/mrd-viz/docs/DEVCONTAINER.md
+++ b/mrd-viz/docs/DEVCONTAINER.md
@@ -1,0 +1,44 @@
+# MRD Viz Dev Container (Scenario B)
+
+Run MRD Viz inside a reproducible dev container: Python 3.12 + the `mrd_viz` backend + the MRD Viz extension + Azure tooling (`az` / `azcopy`), all wired together. This is the recommended way for the research team to use MRD Viz against `.mrd` data stored in Azure.
+
+## Prerequisites
+
+- Docker
+- The **Dev Containers** VS Code extension (`ms-vscode-remote.remote-containers`)
+
+## 1. Open in the container
+
+1. Open the `mrd` repo in VS Code.
+2. Command Palette → **Dev Containers: Reopen in Container** → pick **"MRD Viz extension"**.
+   - The other option, **"mrd"**, is the full-repo toolchain container (conda + MATLAB + C++) and is not needed just to view `.mrd` files.
+3. Wait for the build. `postCreate` installs the `just` and `azcopy` CLIs.
+
+## 2. One-time setup
+
+From the integrated terminal (now connected to the container):
+
+```bash
+cd mrd-viz
+just container-setup
+```
+
+This creates a backend virtualenv at `~/.venvs/mrd-viz`, installs the `mrd_viz` backend into it, builds the extension `.vsix`, and installs it in this window. `mrdViz.pythonPath` is already pointed at that venv, so no further configuration is needed. Reload the window if the extension does not activate immediately.
+
+## 3. Pull `.mrd` data from Azure
+
+Authenticate and copy files into a working directory (`./data` is git-ignored):
+
+```bash
+azcopy login            # or use a SAS URL
+azcopy copy "<source>" ./data --recursive
+```
+
+## 4. Open a file
+
+Double-click any `.mrd` file, or run **MRD Viz: Open File** from the Command Palette.
+
+## Notes
+
+- The extension is **built from source** in the container (needs Node). Planned follow-up: attach a prebuilt `.vsix` to a GitHub Release so the container can install it without building.
+- For manual/local (non-container) setup, see [PACKAGING_AND_INSTALL_RUNBOOK.md](PACKAGING_AND_INSTALL_RUNBOOK.md) and [OFFICIAL_EXT_DEV_RUNBOOK.md](OFFICIAL_EXT_DEV_RUNBOOK.md).

--- a/mrd-viz/docs/DEVCONTAINER.md
+++ b/mrd-viz/docs/DEVCONTAINER.md
@@ -30,7 +30,7 @@ This creates a backend virtualenv at `~/.venvs/mrd-viz`, installs the `mrd_viz` 
 Authenticate and copy files into a working directory (`./data` is git-ignored):
 
 ```bash
-azcopy login            # or use a SAS URL
+az login            # or use a SAS URL
 azcopy copy "<source>" ./data --recursive
 ```
 

--- a/mrd-viz/docs/DEVCONTAINER.md
+++ b/mrd-viz/docs/DEVCONTAINER.md
@@ -38,6 +38,23 @@ azcopy copy "<source>" ./data --recursive
 
 Double-click any `.mrd` file, or run **MRD Viz: Open File** from the Command Palette.
 
+## Restricted / corporate networks
+
+Some corporate networks block direct access to the **public npm registry** (`registry.npmjs.org`) and require an internal mirror instead. Symptom: the container build or `just container-setup` fails with an `npm` **TLS handshake failure** to `registry.npmjs.org`. (PyPI is typically unaffected, so the backend install still works.)
+
+To fix it, point the container's npm at your organization's feed with a **git-ignored** `.npmrc`:
+
+1. Find your feed on the host: `npm config get registry`.
+2. Create `mrd-viz/extension/mrd-viz/.npmrc` (git-ignored) with:
+
+   ```ini
+   registry=https://your-org-feed.example/npm/
+   ```
+
+3. Run `just container-setup` again.
+
+If your feed requires authentication, add the appropriate `_authToken`/credential-provider lines (same as your host `.npmrc`). This file is git-ignored so the internal URL is never committed.
+
 ## Notes
 
 - The extension is **built from source** in the container (needs Node). Planned follow-up: attach a prebuilt `.vsix` to a GitHub Release so the container can install it without building.

--- a/mrd-viz/docs/DEVCONTAINER.md
+++ b/mrd-viz/docs/DEVCONTAINER.md
@@ -27,11 +27,11 @@ This creates a backend virtualenv at `~/.venvs/mrd-viz`, installs the `mrd_viz` 
 
 ## 3. Pull `.mrd` data from Azure
 
-Authenticate and copy files into a working directory (`./data` is git-ignored):
+Authenticate and copy files into the repo-root `data/` directory (git-ignored):
 
 ```bash
 az login            # or use a SAS URL
-azcopy copy "<source>" ./data --recursive
+azcopy copy "<source>" /workspaces/mrd/data --recursive
 ```
 
 ## 4. Open a file

--- a/mrd-viz/docs/DEVCONTAINER.md
+++ b/mrd-viz/docs/DEVCONTAINER.md
@@ -55,6 +55,12 @@ To fix it, point the container's npm at your organization's feed with a **git-ig
 
 If your feed requires authentication, add the appropriate `_authToken`/credential-provider lines (same as your host `.npmrc`). This file is git-ignored so the internal URL is never committed.
 
+## Backend error: a host path or `spawn ... ENOENT`
+
+If opening a `.mrd` file fails and the **Running:** line in the error shows a **host path** (e.g. a Windows `...\.venv\Scripts\python.exe`) instead of `/home/vscode/.venvs/mrd-viz/bin/python`, a workspace `.vscode/settings.json` is overriding the container's interpreter. Workspace settings are bind-mounted into the container and outrank the dev container's setting, so a host `mrdViz.pythonPath` leaks in and the Windows executable doesn't exist in Linux (`ENOENT`).
+
+Fix: remove `mrdViz.pythonPath` from the workspace `.vscode/settings.json`, then reload the window. Keep any host-specific value in your **User** settings instead so it doesn't leak into the container.
+
 ## Notes
 
 - The extension is **built from source** in the container (needs Node). Planned follow-up: attach a prebuilt `.vsix` to a GitHub Release so the container can install it without building.

--- a/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
+++ b/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
@@ -156,6 +156,8 @@ Set `mrdViz.pythonPath` to the path from 6b — via **Settings → search "mrdVi
 
 > **Why set this explicitly?** If `mrdViz.pythonPath` is empty, the extension falls back to a bare `python` on `PATH`. On machines that only have `python3` (common on Linux/macOS), that lookup fails and you get a backend error even though Python is installed. Pointing `mrdViz.pythonPath` at the venv interpreter avoids the `python` vs `python3` ambiguity entirely.
 
+> **Set this in User settings, not Workspace settings, if you also use the dev container.** A workspace `.vscode/settings.json` is bind-mounted into the dev container, so a host path set there (e.g. a Windows `...\.venv\Scripts\python.exe`) leaks into the container and overrides its Linux interpreter — producing a `spawn ... ENOENT` backend error. The dev container sets its own `mrdViz.pythonPath`; keeping the host value in **User** settings prevents the two from colliding.
+
 ### 6d. Open a file
 
 Open any local `.mrd` file (double-click, or **MRD Viz: Open File** from the Command Palette). To generate test `.mrd` files, see section 4 of the [Official Extension Development Runbook](OFFICIAL_EXT_DEV_RUNBOOK.md).

--- a/mrd-viz/justfile
+++ b/mrd-viz/justfile
@@ -38,6 +38,8 @@ container-setup:
     ( cd backend && "$venv/bin/python" -m pip install -e ".[test]" )
     echo ">> Building and installing the MRD Viz extension (VSIX)"
     ( cd extension/mrd-viz && npm ci && npx --yes @vscode/vsce package )
-    code --install-extension "$(ls -t extension/mrd-viz/mrd-viz-*.vsix | head -1)" --force
+    vsix="$(ls -t extension/mrd-viz/mrd-viz-*.vsix 2>/dev/null | head -1)"
+    if [ -z "$vsix" ]; then echo ">> ERROR: no VSIX found in extension/mrd-viz (packaging may have failed)." >&2; exit 1; fi
+    code --install-extension "$vsix" --force
     echo ">> Setup complete. Backend interpreter: $venv/bin/python"
     echo ">> Reload the window if the extension does not activate immediately."

--- a/mrd-viz/justfile
+++ b/mrd-viz/justfile
@@ -25,7 +25,7 @@
 @full-ci: backend-test extension-check extension-test
 
 @extension-package: extension-compile
-    cd extension/mrd-viz && npx --yes @vscode/vsce package
+    cd extension/mrd-viz && cp ../../../LICENSE LICENSE && trap 'rm -f LICENSE' EXIT && npx --yes @vscode/vsce package
 
 # One-time provisioning inside the MRD Viz dev container: backend venv + extension install.
 container-setup:
@@ -37,7 +37,7 @@ container-setup:
     "$venv/bin/python" -m pip install --upgrade pip
     ( cd backend && "$venv/bin/python" -m pip install -e ".[test]" )
     echo ">> Building and installing the MRD Viz extension (VSIX)"
-    ( cd extension/mrd-viz && npm ci && npx --yes @vscode/vsce package )
+    ( cd extension/mrd-viz && npm ci && cp ../../../LICENSE LICENSE && trap 'rm -f LICENSE' EXIT && npx --yes @vscode/vsce package )
     vsix="$(ls -t extension/mrd-viz/mrd-viz-*.vsix 2>/dev/null | head -1)"
     if [ -z "$vsix" ]; then echo ">> ERROR: no VSIX found in extension/mrd-viz (packaging may have failed)." >&2; exit 1; fi
     code --install-extension "$vsix" --force

--- a/mrd-viz/justfile
+++ b/mrd-viz/justfile
@@ -23,3 +23,21 @@
 @ci: backend-test extension-check
 
 @full-ci: backend-test extension-check extension-test
+
+@extension-package: extension-compile
+    cd extension/mrd-viz && npx --yes @vscode/vsce package
+
+# One-time provisioning inside the MRD Viz dev container: backend venv + extension install.
+container-setup:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    venv="$HOME/.venvs/mrd-viz"
+    echo ">> Creating backend virtualenv: $venv"
+    python -m venv "$venv"
+    "$venv/bin/python" -m pip install --upgrade pip
+    ( cd backend && "$venv/bin/python" -m pip install -e ".[test]" )
+    echo ">> Building and installing the MRD Viz extension (VSIX)"
+    ( cd extension/mrd-viz && npm ci && npx --yes @vscode/vsce package )
+    code --install-extension "$(ls -t extension/mrd-viz/mrd-viz-*.vsix | head -1)" --force
+    echo ">> Setup complete. Backend interpreter: $venv/bin/python"
+    echo ">> Reload the window if the extension does not activate immediately."


### PR DESCRIPTION
## Summary
Adds a lightweight, extension-specific dev container so the extension can be used
against `.mrd` data in a reproducible environment (Python 3.12 + `mrd_viz` backend +
MRD Viz extension + Azure `az`/`azcopy`). This is the "Scenario B" workflow: open the
repo, **Reopen in Container → "MRD Viz extension"**, run one setup command, and open
`.mrd` files.

Separate from the bulky repo `.devcontainer` (conda + MATLAB + C++), which pins
Python 3.13 and doesn't provision the backend.

## What's included
- `.devcontainer/mrd-viz/devcontainer.json` — `python:3.12-bookworm` base, `azure-cli`
  feature, presets `mrdViz.pythonPath` to the container venv.
- `.devcontainer/mrd-viz/postCreate.sh` — installs Node (from nodejs.org), `just`, `azcopy`.
- `justfile` `container-setup` recipe — one-time: creates a backend venv, installs
  `mrd_viz`, builds + installs the extension VSIX in-window.
- `mrd-viz/docs/DEVCONTAINER.md` — walkthrough + troubleshooting.
- `.gitignore` (`/data/` azcopy landing zone, git-ignored `.npmrc` hook), `.gitattributes`
  (LF for shell scripts/justfiles).

## User flow
1. Reopen in Container → "MRD Viz extension"
2. `cd mrd-viz && just container-setup`
3. Pull data with `azcopy`, open a `.mrd` file.

Validated end-to-end on a managed/corporate machine.

## Open questions & caveats
- **Installed-VSIX backend discovery is still broken** (`extension.ts` resolves
  `../../backend/.venv` relative to the install dir). The container works only because
  it presets `mrdViz.pythonPath`. A real fix is needed for Scenario A / Marketplace.
- **`mrdViz.pythonPath` is a foot-gun**: it must live in **User** settings, not
  **Workspace** — a workspace `.vscode/settings.json` is bind-mounted into the container
  and overrides the container interpreter (`spawn … ENOENT`). Documented, not enforced.
- **Extension is built from source in-container** (needs Node). Follow-up: attach a
  prebuilt `.vsix` to a GitHub Release so the container installs it without building.
- **Restricted networks**: public npm may be blocked; handled via a git-ignored
  `.npmrc` pointing at an org feed. Auth-protected feeds may need `_authToken`.
- **`postCreate` installs `just`/`azcopy` via `curl | bash`** — endpoint/app-control
  policies can block these; Node version is pinned (`v24.18.0`) and needs manual bumps.
- **Container start requires healthy Docker Desktop ↔ WSL integration** (the WSLg
  wayland mount); this is a local-env dependency, not part of the config.
- Only exercised on Windows + Docker Desktop/WSL so far; not tested on Linux/macOS hosts
  or non-corporate networks.