### PR TITLE
mrd-viz: clean up failed backend venv + clearer setup errors

### DIFF
--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -220,6 +220,7 @@ async function removeIncompleteVenv(venvDir: string, outputChannel: vscode.Outpu
 	try {
 		await rm(venvDir, { recursive: true, force: true });
 		outputChannel.appendLine(`Cleaned up incomplete backend environment (if present): ${venvDir}`);
+	} catch (cleanupError) {
 		const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
 		outputChannel.appendLine(`Warning: could not remove incomplete backend environment at ${venvDir}: ${detail}`);
 	}

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -229,7 +229,7 @@ async function removeIncompleteVenv(venvDir: string, outputChannel: vscode.Outpu
 /** Map a raw failure detail to a short, actionable hint appended to the error notification. */
 function classifyProvisioningFailure(detail: string): string {
 	if (/no matching distribution|could not find a version|404|not found on pypi/i.test(detail)) {
-		return ' The mrd_viz package could not be found in the configured package index.';
+		return ' The mrd-viz package could not be found in the configured package index.';
 	}
 	if (/ssl|tls|proxy|connection|timed out|network|getaddrinfo|econn|temporary failure/i.test(detail)) {
 		return ' This looks like a network/proxy problem reaching the package index.';

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir, rm } from 'node:fs/promises';
+import { mkdir, rename, rm } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
@@ -207,6 +207,9 @@ async function reportProvisioningFailure(error: unknown, venvDir: string, output
 
 	outputChannel.appendLine(`Backend setup failed${where}: ${detail}`);
 	await removeIncompleteVenv(venvDir, outputChannel);
+	// The removed (or quarantined) venv may already be the resolver's cached selection, so drop the
+	// cache defensively — otherwise a stale interpreter path could stay cached after we tore it down.
+	invalidateBackendCache();
 	outputChannel.show(true);
 
 	const hint = classifyProvisioningFailure(detail);
@@ -215,19 +218,53 @@ async function reportProvisioningFailure(error: unknown, venvDir: string, output
 	);
 }
 
-/** Remove a partially built venv so retries start clean and the resolver skips a broken candidate. */
-async function removeIncompleteVenv(venvDir: string, outputChannel: vscode.OutputChannel): Promise<void> {
-	try {
-		await rm(venvDir, { recursive: true, force: true });
+/**
+ * Remove a partially built venv so retries start clean and the resolver skips a broken candidate.
+ * `rm` can fail transiently (notably on Windows, where a just-exited pip may still hold a lock), so
+ * retry a few times; if the directory still can't be deleted, rename it out of the way so its
+ * interpreter path no longer exists (the resolver probes that path with `existsSync` and will skip
+ * the candidate), then make a best-effort delete of the renamed directory.
+ */
+export async function removeIncompleteVenv(venvDir: string, outputChannel: Pick<vscode.OutputChannel, 'appendLine'>): Promise<void> {
+	if (await tryRemoveDirectory(venvDir)) {
 		outputChannel.appendLine(`Cleaned up incomplete backend environment (if present): ${venvDir}`);
-	} catch (cleanupError) {
-		const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
-		outputChannel.appendLine(`Warning: could not remove incomplete backend environment at ${venvDir}: ${detail}`);
+		return;
+	}
+
+	const quarantineDir = `${venvDir}.broken-${Date.now()}`;
+	try {
+		await rename(venvDir, quarantineDir);
+		outputChannel.appendLine(`Could not delete the incomplete backend environment; moved it aside to ${quarantineDir} so it will be ignored.`);
+		void tryRemoveDirectory(quarantineDir);
+	} catch (moveError) {
+		const detail = moveError instanceof Error ? moveError.message : String(moveError);
+		outputChannel.appendLine(`Warning: could not remove or move the incomplete backend environment at ${venvDir}: ${detail}`);
 	}
 }
 
+/** Delete a directory tree, retrying a few times to ride out transient locks. Returns whether it is gone. */
+async function tryRemoveDirectory(dir: string): Promise<boolean> {
+	const attempts = 3;
+	for (let attempt = 1; attempt <= attempts; attempt++) {
+		try {
+			await rm(dir, { recursive: true, force: true });
+			return true;
+		} catch {
+			if (attempt === attempts) {
+				return false;
+			}
+			await delay(attempt * 100);
+		}
+	}
+	return false;
+}
+
+function delay(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 /** Map a raw failure detail to a short, actionable hint appended to the error notification. */
-function classifyProvisioningFailure(detail: string): string {
+export function classifyProvisioningFailure(detail: string): string {
 	if (/no matching distribution|could not find a version|404|not found on pypi/i.test(detail)) {
 		return ' The mrd-viz package could not be found in the configured package index.';
 	}

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -1,6 +1,6 @@
 import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdir } from 'node:fs/promises';
+import { mkdir, rm } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
@@ -141,10 +141,20 @@ async function selectInterpreter(): Promise<void> {
 	void vscode.window.showInformationMessage('MRD Viz Python interpreter updated.');
 }
 
+/** A provisioning step that failed, tagged with the human-readable phase for clear reporting. */
+class BackendSetupError extends Error {
+	constructor(readonly step: string, detail: string) {
+		super(detail);
+		this.name = 'BackendSetupError';
+	}
+}
+
 /**
  * Provision the managed backend virtual environment (resolver candidate #3) in global storage:
  * create a venv from a discovered Python 3.12+ interpreter and `pip install` the backend. Returns
- * true only if every step succeeds; failures are surfaced to the user and the output channel.
+ * true only if every step succeeds; on any failure the half-provisioned venv is removed (so a
+ * stale interpreter can't satisfy the resolver probe and then fail at `import mrd_viz`) and the
+ * cause is surfaced to the user and the output channel.
  */
 async function provisionManagedBackend(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel): Promise<boolean> {
 	const basePython = await findProvisioningPython();
@@ -166,29 +176,65 @@ async function provisionManagedBackend(context: vscode.ExtensionContext, outputC
 				await mkdir(path.dirname(venvDir), { recursive: true });
 
 				progress.report({ message: 'Creating virtual environment\u2026' });
-				await runProvisioningStep(basePython, ['-m', 'venv', venvDir], outputChannel);
+				await runProvisioningStep('creating the virtual environment', basePython, ['-m', 'venv', venvDir], outputChannel);
 
 				progress.report({ message: 'Upgrading pip\u2026' });
-				await runProvisioningStep(venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip'], outputChannel);
+				await runProvisioningStep('upgrading pip', venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip'], outputChannel);
 
 				progress.report({ message: 'Installing the mrd_viz backend\u2026' });
 				const installArgs = installTarget === 'mrd-viz'
 					? ['-m', 'pip', 'install', 'mrd-viz']
 					: ['-m', 'pip', 'install', '-e', installTarget];
-				await runProvisioningStep(venvPython, installArgs, outputChannel);
+				await runProvisioningStep('installing the mrd_viz backend', venvPython, installArgs, outputChannel);
 
 				return true;
 			} catch (error) {
-				const message = error instanceof Error ? error.message : String(error);
-				outputChannel.appendLine(`Backend setup failed: ${message}`);
-				outputChannel.show(true);
-				void vscode.window.showErrorMessage(
-					`MRD Viz backend setup failed: ${message}. See the MRD Viz output channel for details, or use "Select Python Interpreter\u2026" instead.`,
-				);
+				await reportProvisioningFailure(error, venvDir, outputChannel);
 				return false;
 			}
 		},
 	);
+}
+
+/**
+ * Log the failure, remove the incomplete venv, and show a user-facing message that names the
+ * step that failed and (when recognizable) hints at the cause.
+ */
+async function reportProvisioningFailure(error: unknown, venvDir: string, outputChannel: vscode.OutputChannel): Promise<void> {
+	const step = error instanceof BackendSetupError ? error.step : undefined;
+	const detail = error instanceof Error ? error.message : String(error);
+	const where = step ? ` while ${step}` : '';
+
+	outputChannel.appendLine(`Backend setup failed${where}: ${detail}`);
+	await removeIncompleteVenv(venvDir, outputChannel);
+	outputChannel.show(true);
+
+	const hint = classifyProvisioningFailure(detail);
+	void vscode.window.showErrorMessage(
+		`MRD Viz backend setup failed${where}: ${detail}.${hint} See the MRD Viz output channel for details, or use "Select Python Interpreter\u2026" instead.`,
+	);
+}
+
+/** Remove a partially built venv so retries start clean and the resolver skips a broken candidate. */
+async function removeIncompleteVenv(venvDir: string, outputChannel: vscode.OutputChannel): Promise<void> {
+	try {
+		await rm(venvDir, { recursive: true, force: true });
+		outputChannel.appendLine(`Removed incomplete backend environment: ${venvDir}`);
+	} catch (cleanupError) {
+		const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
+		outputChannel.appendLine(`Warning: could not remove incomplete backend environment at ${venvDir}: ${detail}`);
+	}
+}
+
+/** Map a raw failure detail to a short, actionable hint appended to the error notification. */
+function classifyProvisioningFailure(detail: string): string {
+	if (/no matching distribution|could not find a version|404|not found on pypi/i.test(detail)) {
+		return ' The mrd_viz package could not be found in the configured package index.';
+	}
+	if (/ssl|tls|proxy|connection|timed out|network|getaddrinfo|econn|temporary failure/i.test(detail)) {
+		return ' This looks like a network/proxy problem reaching the package index.';
+	}
+	return '';
 }
 
 /** Locate a Python 3.12+ interpreter on PATH suitable for building the backend venv. */
@@ -230,7 +276,7 @@ function repoBackendInstallTarget(context: vscode.ExtensionContext): string | un
 	return existsSync(path.join(backendDir, 'pyproject.toml')) ? backendDir : undefined;
 }
 
-function runProvisioningStep(command: string, args: string[], outputChannel: vscode.OutputChannel): Promise<void> {
+function runProvisioningStep(step: string, command: string, args: string[], outputChannel: vscode.OutputChannel): Promise<void> {
 	outputChannel.appendLine(`Running: ${command} ${args.join(' ')}`);
 	return new Promise((resolve, reject) => {
 		execFile(command, args, { timeout: 600000, windowsHide: true, maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
@@ -238,7 +284,7 @@ function runProvisioningStep(command: string, args: string[], outputChannel: vsc
 			appendIfPresent(outputChannel, 'stderr', stderr);
 			if (error) {
 				const detail = (stderr.trim().split(/\r?\n/).pop() || error.message).trim();
-				reject(new Error(detail));
+				reject(new BackendSetupError(step, detail));
 				return;
 			}
 			resolve();

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -219,8 +219,7 @@ async function reportProvisioningFailure(error: unknown, venvDir: string, output
 async function removeIncompleteVenv(venvDir: string, outputChannel: vscode.OutputChannel): Promise<void> {
 	try {
 		await rm(venvDir, { recursive: true, force: true });
-		outputChannel.appendLine(`Removed incomplete backend environment: ${venvDir}`);
-	} catch (cleanupError) {
+		outputChannel.appendLine(`Cleaned up incomplete backend environment (if present): ${venvDir}`);
 		const detail = cleanupError instanceof Error ? cleanupError.message : String(cleanupError);
 		outputChannel.appendLine(`Warning: could not remove incomplete backend environment at ${venvDir}: ${detail}`);
 	}

--- a/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
+++ b/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
@@ -1,9 +1,11 @@
-import { readFileSync } from 'node:fs';
+import { readFileSync, existsSync } from 'node:fs';
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import * as os from 'node:os';
 import * as path from 'node:path';
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 
-import { getOpenWithMrdEditorArgs } from '../extension';
+import { classifyProvisioningFailure, getOpenWithMrdEditorArgs, removeIncompleteVenv } from '../extension';
 import { MRD_VIEW_TYPE } from '../mrdEditorProvider';
 import { getMrdBackendMissingHtml } from '../webviewHtml';
 import { getMrdErrorHtml } from '../stateHtml';
@@ -114,7 +116,50 @@ suite('MRD Viz Extension', () => {
 	});
 });
 
+suite('MRD Viz backend provisioning', () => {
+	test('hints at a missing package using the pip distribution name (mrd-viz, not mrd_viz)', () => {
+		const hint = classifyProvisioningFailure('ERROR: No matching distribution found for mrd-viz');
+		assert.match(hint, /mrd-viz package could not be found/);
+		assert.ok(!/mrd_viz/.test(hint), 'the hint should use the pip distribution name mrd-viz, not the import name mrd_viz');
+	});
+
+	test('hints at a network/proxy problem reaching the package index', () => {
+		const hint = classifyProvisioningFailure('Could not fetch URL https://pypi.org/simple/: connection timed out');
+		assert.match(hint, /network\/proxy problem/);
+	});
+
+	test('returns no hint for an unrecognized failure', () => {
+		assert.strictEqual(classifyProvisioningFailure('pip exited with an unexpected error'), '');
+	});
+
+	test('deletes a partially built venv so a later retry starts clean', async () => {
+		const venvDir = await makeFakeVenv();
+		const messages: string[] = [];
+		await removeIncompleteVenv(venvDir, { appendLine: message => messages.push(message) });
+
+		assert.ok(!existsSync(venvDir), 'the incomplete venv directory should be removed');
+		assert.ok(messages.some(message => message.includes('Cleaned up incomplete backend environment')));
+	});
+
+	test('is a no-op (no throw) when the venv directory is already gone', async () => {
+		const missing = path.join(os.tmpdir(), `mrd-viz-missing-${Date.now()}`);
+		const messages: string[] = [];
+		await removeIncompleteVenv(missing, { appendLine: message => messages.push(message) });
+
+		assert.ok(!existsSync(missing));
+		assert.ok(messages.some(message => message.includes('Cleaned up incomplete backend environment')));
+	});
+});
+
 function readPackageJson(): ExtensionPackageJson {
 	const packagePath = path.resolve(__dirname, '..', '..', 'package.json');
 	return JSON.parse(readFileSync(packagePath, 'utf8')) as ExtensionPackageJson;
+}
+
+async function makeFakeVenv(): Promise<string> {
+	const dir = await mkdtemp(path.join(os.tmpdir(), 'mrd-viz-venv-'));
+	await mkdir(path.join(dir, 'bin'), { recursive: true });
+	await writeFile(path.join(dir, 'bin', 'python'), '#!/bin/sh\n');
+	await writeFile(path.join(dir, 'pyvenv.cfg'), 'home = /usr\n');
+	return dir;
 }


### PR DESCRIPTION
﻿Fixes the partially-provisioned backend venv left behind by "Set Up Backend Automatically...".

**Problem:** on any failure, provisionManagedBackend left a half-built venv in globalStorage/backend-venv. The interpreter still existed, so the resolver kept selecting it, passing the --version probe and then failing at import mrd_viz -- and retrying reproduced the same broken state.

**Fix:**
- Remove the incomplete venv on failure (mirrors postCreate.sh), so retries start clean and the resolver falls through to the next candidate.
- Tag failures with the step that failed (creating venv / upgrading pip / installing backend) and add a short hint for package-not-found vs. network/proxy causes.

Scope: single file (extension.ts); no change to commands or public surface.
