### PR TITLE
mrd-viz: deterministic two-tier backend resolution

### DIFF
--- a/.devcontainer/mrd-viz/devcontainer.json
+++ b/.devcontainer/mrd-viz/devcontainer.json
@@ -18,9 +18,10 @@
     "vscode": {
       "settings": {
         // `just container-setup` creates this venv; pointing the extension at it
-        // explicitly avoids the installed-VSIX discovery gap and the python/python3
-        // PATH ambiguity.
-        "mrdViz.pythonPath": "/home/vscode/.venvs/mrd-viz/bin/python",
+        // explicitly (via the developer override) avoids the installed-VSIX discovery
+        // gap and the python/python3 PATH ambiguity. backendPath is machine-scoped, so
+        // this applies as a container remote setting and never leaks back to the host.
+        "mrdViz.backendPath": "/home/vscode/.venvs/mrd-viz/bin/python",
         "python.defaultInterpreterPath": "/home/vscode/.venvs/mrd-viz/bin/python"
       },
       "extensions": [

--- a/.devcontainer/mrd-viz/devcontainer.json
+++ b/.devcontainer/mrd-viz/devcontainer.json
@@ -14,6 +14,16 @@
   // which is blocked on some corporate networks. Project provisioning (backend +
   // the MRD Viz extension) is a one-time `just container-setup` you run afterwards.
   "postCreateCommand": "bash .devcontainer/mrd-viz/postCreate.sh",
+  // Ordered package-index candidates (Microsoft-internal mirror first, public
+  // registry as fallback). `.devcontainer/mrd-viz/select-pkg-index.sh` picks the
+  // first reachable one and exports PIP_INDEX_URL / npm_config_registry, so the
+  // internal feed lives here — not in a hidden dotfile — and external contributors
+  // fall back to the public registry automatically. Override either list, or set
+  // PIP_INDEX_URL / npm_config_registry directly, to force a specific feed.
+  "remoteEnv": {
+    "MRD_PIP_INDEX_URLS": "https://packagefeedproxy.microsoft.io/pypi/simple/ https://pypi.org/simple/",
+    "MRD_NPM_REGISTRIES": "https://packagefeedproxy.microsoft.io/npm/ https://registry.npmjs.org/"
+  },
   "customizations": {
     "vscode": {
       "settings": {

--- a/.devcontainer/mrd-viz/postCreate.sh
+++ b/.devcontainer/mrd-viz/postCreate.sh
@@ -57,6 +57,9 @@ backend_ready=0
 if [ -x "$venv/bin/python" ] && "$venv/bin/python" -m mrd_viz.cli --version >/dev/null 2>&1; then
 	backend_ready=1
 elif [ -d "$backend_dir" ]; then
+	# Point pip at the first reachable index (internal mirror, else public PyPI).
+	# shellcheck source=./select-pkg-index.sh
+	source "$repo_root/.devcontainer/mrd-viz/select-pkg-index.sh"
 	echo ">> Provisioning MRD Viz backend virtualenv: $venv"
 	if python3 -m venv "$venv" \
 		&& "$venv/bin/python" -m pip install --upgrade pip \

--- a/.devcontainer/mrd-viz/postCreate.sh
+++ b/.devcontainer/mrd-viz/postCreate.sh
@@ -46,7 +46,7 @@ if ! command -v azcopy >/dev/null 2>&1; then
 fi
 
 # Backend provisioning (best-effort, non-fatal). The dev container points
-# mrdViz.pythonPath at this venv, so create it and install the mrd_viz backend
+# mrdViz.backendPath at this venv, so create it and install the mrd_viz backend
 # now for a turnkey first run. This only needs PyPI (mrd-python/numpy/pillow),
 # which is typically reachable even where the npm registry is blocked; the guard
 # keeps a failure from aborting container creation and falls back to the manual
@@ -73,7 +73,7 @@ if [ "$backend_ready" -eq 1 ]; then
 
 ============================================================
  MRD Viz dev container is ready. Backend is installed and
- mrdViz.pythonPath points at ~/.venvs/mrd-viz, so opening a
+ mrdViz.backendPath points at ~/.venvs/mrd-viz, so opening a
  .mrd file should work out of the box.
 
  If the MRD Viz extension itself is not installed yet, run:

--- a/.devcontainer/mrd-viz/select-pkg-index.sh
+++ b/.devcontainer/mrd-viz/select-pkg-index.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+# Pick the first reachable package index/registry from an ordered, space-separated
+# candidate list and export the variables pip and npm read natively
+# (PIP_INDEX_URL, npm_config_registry). Source this before running pip/npm.
+#
+# Candidate ladder (same idea as the backend resolver): the Microsoft-internal
+# mirror is tried first, the public registry second. Microsoft-internal devs on a
+# restricted network get the mirror; external devs fall back to the public
+# registry automatically. The lists come from devcontainer.json (remoteEnv):
+#   MRD_PIP_INDEX_URLS   e.g. "https://internal/pypi/simple/ https://pypi.org/simple/"
+#   MRD_NPM_REGISTRIES   e.g. "https://internal/npm/ https://registry.npmjs.org/"
+# When unset (running outside the dev container), they default to public only.
+#
+# Override the final choice by exporting PIP_INDEX_URL / npm_config_registry
+# yourself before sourcing; an explicit value is always respected.
+
+: "${MRD_PIP_INDEX_URLS:=https://pypi.org/simple/}"
+: "${MRD_NPM_REGISTRIES:=https://registry.npmjs.org/}"
+
+# Echo the first URL in $1 (space-separated) whose host completes an HTTPS request
+# within a short timeout. Any HTTP response (even 404) counts as reachable; only a
+# TLS handshake / connection failure — the restricted-network symptom — is a miss.
+_mrd_first_reachable() {
+	local url
+	for url in $1; do
+		if curl -sS --max-time 6 -o /dev/null -I "$url" >/dev/null 2>&1; then
+			printf '%s' "$url"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# pip
+if [ -n "${PIP_INDEX_URL:-}" ]; then
+	echo ">> Using PyPI index (from PIP_INDEX_URL): $PIP_INDEX_URL"
+elif _pip_url="$(_mrd_first_reachable "$MRD_PIP_INDEX_URLS")"; then
+	export PIP_INDEX_URL="$_pip_url"
+	echo ">> Using PyPI index: $PIP_INDEX_URL"
+else
+	echo ">> WARNING: no reachable PyPI index among: $MRD_PIP_INDEX_URLS" >&2
+	echo ">> If you are on a restricted/corporate network, run this and retry:" >&2
+	echo ">>     export PIP_INDEX_URL=\"${MRD_PIP_INDEX_URLS%% *}\"" >&2
+fi
+
+# npm
+if [ -n "${npm_config_registry:-}" ]; then
+	echo ">> Using npm registry (from npm_config_registry): $npm_config_registry"
+elif _npm_url="$(_mrd_first_reachable "$MRD_NPM_REGISTRIES")"; then
+	export npm_config_registry="$_npm_url"
+	echo ">> Using npm registry: $npm_config_registry"
+else
+	echo ">> WARNING: no reachable npm registry among: $MRD_NPM_REGISTRIES" >&2
+	echo ">> If you are on a restricted/corporate network, run this and retry:" >&2
+	echo ">>     export npm_config_registry=\"${MRD_NPM_REGISTRIES%% *}\"" >&2
+fi
+
+unset -f _mrd_first_reachable
+unset _pip_url _npm_url

--- a/mrd-viz/docs/BACKEND_INSTALL_MODES.md
+++ b/mrd-viz/docs/BACKEND_INSTALL_MODES.md
@@ -2,8 +2,8 @@
 
 How the MRD Viz extension finds a working backend across the four ways it can be installed, which
 Python interpreter actually runs, and the open questions around interpreter-precedence (issue #3).
-The first half documents the **current** behavior; [Target architecture (implemented)](#target-architecture-implemented)
-at the end lays out a cleaner, deterministic redesign.
+The first half documents the **pre-refactor** behavior (historical context); [Target architecture (implemented)](#target-architecture-implemented)
+at the end describes the shipped, deterministic design.
 
 Related runbooks:
 

--- a/mrd-viz/docs/BACKEND_INSTALL_MODES.md
+++ b/mrd-viz/docs/BACKEND_INSTALL_MODES.md
@@ -2,7 +2,7 @@
 
 How the MRD Viz extension finds a working backend across the four ways it can be installed, which
 Python interpreter actually runs, and the open questions around interpreter-precedence (issue #3).
-The first half documents the **current** behavior; [Target architecture (proposed)](#target-architecture-proposed)
+The first half documents the **current** behavior; [Target architecture (implemented)](#target-architecture-implemented)
 at the end lays out a cleaner, deterministic redesign.
 
 Related runbooks:
@@ -141,9 +141,13 @@ the environment-appropriate scope (Machine/Remote in a container, Global on host
 
 ---
 
-# Target architecture (proposed)
+# Target architecture (implemented)
 
-Everything above documents the **current** state. This section is the proposed redesign.
+> **Status:** implemented in the deterministic-resolution change (`mrdViz.backendPath`, two-tier
+> resolver, machine scope). The first half of this document is retained as historical context for
+> the pre-refactor 5-candidate behavior.
+
+Everything above documents the **pre-refactor** state. This section describes the shipped design.
 
 ## Why the current search is scattered
 

--- a/mrd-viz/docs/BACKEND_INSTALL_MODES.md
+++ b/mrd-viz/docs/BACKEND_INSTALL_MODES.md
@@ -1,0 +1,331 @@
+# MRD Viz Backend Install Modes & Interpreter Resolution
+
+How the MRD Viz extension finds a working backend across the four ways it can be installed, which
+Python interpreter actually runs, and the open questions around interpreter-precedence (issue #3).
+The first half documents the **current** behavior; [Target architecture (proposed)](#target-architecture-proposed)
+at the end lays out a cleaner, deterministic redesign.
+
+Related runbooks:
+
+- [Extension Release Runbook](EXTENSION_RELEASE_RUNBOOK.md) — how the VSIX is released (GitHub Release vs. Marketplace).
+- [Packaging & Local Install Runbook](PACKAGING_AND_INSTALL_RUNBOOK.md) — build/install a VSIX locally.
+- [Dev Container](DEVCONTAINER.md) — the containerized setup.
+
+## Distribution channels (three separate things)
+
+These are independent and often confused:
+
+| Channel | Ships what | User action | Notes |
+|---|---|---|---|
+| **VS Code Marketplace** | the extension (VSIX) | one-click Install | not wired up yet; see the release runbook |
+| **GitHub Release** | the extension (VSIX) | download + `code --install-extension` | already implemented |
+| **PyPI** | the Python **backend** (`pip install mrd-viz`) | pip, inside a venv | **not published** — so `pip install mrd-viz` currently 404s |
+
+**Decision:** ship the backend as a **bundled binary inside the VSIX** (PyInstaller), so end users need
+neither PyPI nor a local Python. PyPI/`pip install` stays a fallback for source/dev workflows only.
+
+## The four install modes
+
+| Environment | Extension source | Backend source (recommended) | Resolver candidate that fires |
+|---|---|---|---|
+| **Dev container** | built from repo (`just container-setup`) | editable install of `mrd-viz/backend` into `~/.venvs/mrd-viz`, referenced by `mrdViz.pythonPath` | **#1** configured path |
+| **Local repo (F5 / contributor)** | F5 Extension Development Host, built from source | repo `backend/.venv` | **#4** repo venv (or **#1** if configured) |
+| **Local, released VSIX, no repo** | Marketplace / GitHub Release VSIX | **bundled binary in the VSIX** | **#2** bundled binary |
+| **Restricted / air-gapped** | any | pre-provisioned venv, or bundled binary | **#2** or **#3** |
+
+> The hidden dependency today: modes that "just work" for contributors rely on the repo checkout
+> (candidate #4) or a dev-container-provisioned venv (candidate #1). A plain released VSIX has
+> **only** candidate #2 (bundled binary) or a user-provisioned venv (#3) — which is why the bundled
+> binary must be the canonical end-user backend.
+
+## Interpreter resolution order
+
+`resolveBackend()` in [`backendResolver.ts`](../extension/mrd-viz/src/backendResolver.ts) probes each
+candidate with `--version` and uses the first that responds. Anything above candidate #5 is an
+**explicit path** — ambient `python` on `PATH` is only ever used as the last resort.
+
+```mermaid
+flowchart TD
+    Start([Open a .mrd file]) --> C1{1. mrdViz.pythonPath configured?}
+    C1 -- yes --> P1[probe: python -m mrd_viz.cli --version]
+    P1 -- ok --> U1([Use configured interpreter])
+    P1 -- fail --> C2
+    C1 -- no --> C2{2. Bundled binary in VSIX media/backend?}
+    C2 -- exists --> P2[probe: mrd-viz --version]
+    P2 -- ok --> U2([Use bundled binary])
+    P2 -- fail --> C3
+    C2 -- absent --> C3{3. Managed venv in globalStorage/backend-venv?}
+    C3 -- exists --> P3[probe --version]
+    P3 -- ok --> U3([Use managed venv])
+    P3 -- fail --> C4
+    C3 -- absent --> C4{4. Repo backend/.venv?}
+    C4 -- exists --> P4[probe --version]
+    P4 -- ok --> U4([Use repo venv])
+    P4 -- fail --> C5
+    C4 -- absent --> C5{5. python / python3 on PATH}
+    C5 --> P5[probe --version]
+    P5 -- ok --> U5([Use PATH interpreter])
+    P5 -- fail --> Fail([Show &quot;backend missing&quot; page + guided setup])
+```
+
+## Which Python actually runs — and the scope trap (issue #3)
+
+Candidate #1 comes from `getConfiguredPythonPath()`, which reads `mrdViz.pythonPath` via
+`inspect()` and takes the **first defined** of:
+
+```
+workspaceFolderValue  ??  workspaceValue  ??  globalValue
+```
+
+The dev container sets `mrdViz.pythonPath` through `customizations.vscode.settings`, so a
+workspace-scoped value **shadows anything the user sets in User (global) settings**.
+
+```mermaid
+flowchart TD
+    A[getConfiguredPythonPath] --> B[inspect mrdViz.pythonPath]
+    B --> WF{workspaceFolderValue defined?}
+    WF -- yes --> R([use it — shadows User settings])
+    WF -- no --> WS{workspaceValue defined?}
+    WS -- yes --> R
+    WS -- no --> G{globalValue defined?}
+    G -- yes --> RG([use User/global value])
+    G -- no --> D([treated as unset → skip candidate #1])
+```
+
+### Consequences observed
+
+- A user overriding `mrdViz.pythonPath` in **User** settings is silently ignored inside the dev
+  container (the workspace value wins).
+- "Set Up Backend Automatically…" builds a working managed venv but **never writes its path to any
+  settings scope**, so the resolver only reaches it (candidate #3) by *falling through* a probe
+  failure of the stale configured path.
+- The extension's managed venv (`globalStorage/backend-venv`) and the dev container's venv
+  (`~/.venvs/mrd-viz`) are **two different environments** that don't know about each other.
+
+### Yulia's proposed fix
+
+1. Use `configuration.get<string>('pythonPath')` (respects VS Code's normal precedence) instead of
+   hand-rolling the `inspect()` fallback.
+2. Have `provisionManagedBackend` write the managed venv path to `Global` at the end, so the guided
+   flow leaves settings self-documenting.
+
+### ⚠️ Trap to investigate before implementing
+
+`mrdViz.pythonPath` declares `"default": "python"` in
+[`package.json`](../extension/mrd-viz/package.json). So `configuration.get<string>('pythonPath')`
+**never returns `undefined`** — when unset it returns the default `"python"`. That would make
+resolver **candidate #1 always fire with `"python"`**, collapsing candidates #2–#4 (bundled binary,
+managed venv, repo venv) unless `"python"` happens to fail its probe.
+
+Options to reconcile precedence **and** preserve the candidate ladder:
+
+- **(a)** Remove the `"default": "python"` (make it absent/`null`) and switch to `get()`. Cleanest;
+  unset then means "skip candidate #1" and normal precedence applies.
+- **(b)** Keep `inspect()` but treat the package.json default as "not configured," and also read the
+  Remote/machine scope the dev container actually writes to.
+
+Also open: whether writing the provisioned venv to `Global` inside a dev container could **leak a
+container path back to the host** (if Global settings are shared), so the write may need to target
+the environment-appropriate scope (Machine/Remote in a container, Global on host).
+
+### Open boundary questions (host vs. container, store vs. dev build)
+
+- **Do I uninstall the Marketplace build to debug my changes?** For **F5 (Extension Development
+  Host)**: no — the dev host runs your source copy and disables the installed one for that window.
+  For **installing a locally built VSIX** into normal VS Code: effectively yes — VS Code won't run
+  two extensions with the same `publisher.name`; installing the VSIX replaces the Marketplace one
+  (bump the version or use a separate `--profile` to avoid the clobber).
+- **Unify the two venvs?** Pointing the dev container at the same managed venv the extension
+  provisions (one source of truth per environment) would remove most of the "which Python is used"
+  ambiguity and pairs naturally with fix #2 above.
+
+---
+
+# Target architecture (proposed)
+
+Everything above documents the **current** state. This section is the proposed redesign.
+
+## Why the current search is scattered
+
+The five-candidate ladder is a fossil record of the development process, not a design. Each
+environment the extension was built in added its own candidate, and the resolver became the *union*
+of every workflow's needs, probed linearly at runtime:
+
+| Candidate | Added while working in… |
+|---|---|
+| #1 `mrdViz.pythonPath` | the **dev container** (point at `~/.venvs/mrd-viz`) |
+| #2 bundled binary | the **released VSIX** (end users with no Python) |
+| #3 managed venv (globalStorage) | **guided setup** recovery |
+| #4 repo `backend/.venv` | the **local F5** contributor loop |
+| #5 `python` / `python3` on PATH | catch-all "maybe something runs" |
+
+Blind linear search trades a clear *early* failure for a confusing *late* one: it silently selects
+*something*, that candidate passes its `--version` probe, and then it fails at actual use. This is
+the root of both the "which Python is actually used?" confusion and the issue #2/#3 bugs.
+
+## The requirement is two audiences, not five environments
+
+Once you split by *who* is running the backend, the environments collapse to two contracts:
+
+1. **End users** (installed VSIX): must work with **zero config and no local Python**. Should never
+   see `mrdViz.pythonPath`.
+2. **Backend developers** (F5, dev container): are *editing the Python*, so they must point at their
+   **editable source**; a frozen binary would defeat the purpose.
+
+## The single source of truth already exists
+
+- **Logically** there is one backend: the Python package at `mrd-viz/backend`.
+- **For end users**, its distributable form is the **PyInstaller binary** — Python + deps baked in,
+  needs nothing on the host. CI already builds it per-platform and ships it *inside* each VSIX at
+  `media/backend/mrd-viz[.exe]`. Nothing is copied at runtime; the binary rides along in the
+  extension's own directory, so the extension knows exactly one path, environment-independent.
+
+So the per-platform binaries are frozen builds of a single logical source (the package). That is the
+source of truth for end users; the editable package is the source of truth for developers.
+
+## What "probe" means
+
+To **probe** a candidate is to *run* it with `--version` under a short timeout and require exit
+code 0 — not merely check that the file exists:
+
+- bundled binary → `mrd-viz --version`
+- interpreter → `python -m mrd_viz.cli --version`
+
+A successful probe proves the backend is actually importable/runnable (it catches a broken venv, a
+wrong-arch or wrong-glibc binary, or a missing `mrd_viz` module) *before* the extension commits to
+it. This is the existing `validateBackend()` step — the redesign keeps it, but applies it to at
+most two candidates instead of five.
+
+## The selection signal: presence of `mrdViz.pythonPath`
+
+The setting itself distinguishes the two audiences:
+
+- **Set** → a backend developer who wants their editable checkout/venv. Use it; **fail loud** if it
+  is broken (never silently fall back).
+- **Unset** → an end user. Use the **bundled binary**; never probe `PATH` or auto-provision silently.
+
+> ⚠️ **Precondition (issue #3 trap):** `mrdViz.pythonPath` currently declares `"default": "python"`,
+> so "unset" is indistinguishable from the literal string `python`. This default must be removed (or
+> treated as unset) for *absence* to reliably mean "end user." Consider renaming to
+> `mrdViz.backendPath` and accepting either an interpreter or a binary path.
+
+## Proposed resolution: deterministic, fail-loud
+
+```mermaid
+flowchart TD
+    Start([Need the backend]) --> Dev{mrdViz.pythonPath explicitly set?}
+    Dev -- yes, developer --> ProbeDev[probe it: python -m mrd_viz.cli --version]
+    ProbeDev -- ok --> UseDev([Use configured interpreter])
+    ProbeDev -- fail --> ErrDev([Fail loud: your configured interpreter is broken -- no fallback])
+    Dev -- no, end user --> Bin{Bundled binary present for this platform?}
+    Bin -- yes --> ProbeBin[probe it: mrd-viz --version]
+    ProbeBin -- ok --> UseBin([Use bundled binary])
+    ProbeBin -- fail --> ErrBin([Fail loud: bundled backend not runnable + one recovery action])
+    Bin -- no --> Recover([Unsupported platform: offer guided setup ONCE; do not probe PATH])
+```
+
+Rules:
+
+- **Default = bundled binary.** No setting, no search, for the common case.
+- **`mrdViz.pythonPath` = explicit developer/power-user override**, set once. The dev container keeps
+  doing exactly this, so it is not a special case — just a configured developer.
+- **Drop #3/#4/#5 as always-on candidates.** No repo-`.venv` autodiscovery, no `python`/`python3`
+  PATH probing, no silent managed-venv fallback.
+- **Guided setup is demoted** from "candidate #3" to an **explicit recovery command**, offered only
+  when there is no bundled binary for the platform. It is no longer part of normal resolution.
+- **Every failure is loud and names exactly one next action.**
+
+## Install modes under the new model
+
+| Environment | `mrdViz.pythonPath` | Backend used |
+|---|---|---|
+| Local, released VSIX (end user) | unset | **bundled binary** |
+| Dev container | set → `~/.venvs/mrd-viz` | that editable venv |
+| Local repo / F5 (contributor) | set → `backend/.venv` | that editable venv |
+| Unsupported platform / no binary | unset | guided-setup recovery (explicit, one-time) |
+
+## Preconditions & open questions
+
+1. **Linux glibc (blocker).** Making the bundled binary the default requires the manylinux_2_28
+   build (repo follow-up #2), or Linux end users have no working default. Fix this first.
+2. **Override naming.** Keep `mrdViz.pythonPath`, or introduce `mrdViz.backendPath` that accepts an
+   interpreter *or* a binary? Removing the `default: "python"` is required either way.
+3. **Dev container.** Treat it purely as "a developer using the override"; stop provisioning a
+   managed venv as a hidden runtime candidate.
+4. **Binary size.** Each per-platform VSIX carries a PyInstaller bundle (tens of MB). Acceptable for
+   the zero-config guarantee?
+
+## Levels of abstraction — where each backend actually lives
+
+The terms `local`, `venv`, `dev container`, and `VSIX` get conflated because they are **not the same
+kind of thing**. They sit on three independent axes:
+
+| Axis | Question it answers | Values |
+|---|---|---|
+| **Runtime context** | *Where does code run?* | host machine · dev container (Docker) |
+| **Backend delivery** | *Where does the Python backend come from?* | system Python · venv · **bundled binary** |
+| **Extension delivery** | *How did the extension get installed?* | F5 dev host · local VSIX · Marketplace |
+
+The extension-delivery axis is orthogonal — it only decides how the "MRD Viz extension" box below
+got onto disk. The structural picture is about the other two: a **runtime context** contains an
+extension host, the extension contains an *optional* bundled binary, and the same context *also*
+contains external Python environments the extension could spawn.
+
+```mermaid
+flowchart TB
+    subgraph HostCtx["Runtime context A: Host machine (no container)"]
+        direction TB
+        HEH["VS Code extension host (Node), host OS"]
+        HEH --> HExt["MRD Viz extension package"]
+        subgraph HInside["inside the extension package"]
+            HBin["Bundled binary<br/>media/backend/mrd-viz<br/>(self-contained Python + mrd_viz + deps)"]
+        end
+        HExt --> HInside
+        subgraph HOutside["Host OS userland (outside the extension)"]
+            HSys["System Python on PATH"]
+            HRepo["Repo venv: backend/.venv"]
+            HMan["Managed venv: globalStorage/backend-venv"]
+        end
+        HExt -. can spawn .-> HOutside
+    end
+
+    subgraph DCtx["Runtime context B: Dev container (Docker) — a parallel, self-contained stack"]
+        direction TB
+        DEH["VS Code Server extension host (Node), container OS"]
+        DEH --> DExt["MRD Viz extension package (built from source)"]
+        subgraph DInside["inside the extension package"]
+            DBin["Bundled binary<br/>(only if the built VSIX shipped one)"]
+        end
+        DExt --> DInside
+        subgraph DOutside["Container OS userland (outside the extension)"]
+            DVenv["venv: ~/.venvs/mrd-viz<br/>(editable mrd_viz)"]
+        end
+        DExt -. can spawn .-> DOutside
+    end
+```
+
+**How to read it (outer → inner):**
+
+1. **Runtime context** is the outermost boundary. The host and the dev container are *parallel*
+   copies of the same stack, **not** one inside the other for our purposes: nothing crosses the
+   boundary. A host venv is invisible in the container and vice-versa — which is exactly why a host
+   `mrdViz.pythonPath` that leaks into a container fails with `ENOENT` (the Windows path doesn't
+   exist in Linux).
+2. **Extension host** (Node) runs *within* a context — on the host normally, or inside the container
+   (VS Code Server) when you "Reopen in Container."
+3. **The extension package** sits inside the extension host. How it got there (F5 / VSIX /
+   Marketplace) is the orthogonal delivery axis and doesn't change this shape.
+4. **The backend** is reached one of two ways:
+   - **Bundled binary** — a whole Python environment *collapsed into one file that lives inside the
+     extension package*. Self-contained; travels with the VSIX.
+   - **External Python env** — a `venv` or system Python in the *same context's* OS userland,
+     *outside* the extension, which the extension spawns.
+
+That inside-vs-outside distinction is the crux: the bundled binary is the only backend that is part
+of the extension itself; every venv/system-Python option is an external dependency of whichever
+context you happen to be in.
+
+> The [proposed resolution](#proposed-resolution-deterministic-fail-loud) deliberately consults only
+> **two** of these boxes — the external Python env *if* `mrdViz.pythonPath` is set (developer), or the
+> bundled binary inside the extension (end user). Every other box in this picture is intentionally
+> ignored, which is what makes "which Python is used?" answerable.

--- a/mrd-viz/docs/BACKEND_RESOLUTION_IMPLEMENTATION_PLAN.md
+++ b/mrd-viz/docs/BACKEND_RESOLUTION_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,147 @@
+# MRD Viz — Deterministic Backend Resolution: Implementation Plan
+
+Implementation plan for replacing the 5-candidate backend search with a deterministic, fail-loud
+resolver. Design rationale and diagrams live in
+[BACKEND_INSTALL_MODES.md](BACKEND_INSTALL_MODES.md) (see "Target architecture"); this document is
+the build plan.
+
+## Invariant
+
+- **One source of truth:** the `mrd_viz` Python package (`mrd-viz/backend`). The bundled binary is a
+  PyInstaller *snapshot* of that exact package ([`packaging/entry.py`](../backend/packaging/entry.py)
+  → `mrd_viz.cli:main`), so developer edits are reflected on the next binary rebuild.
+- **Resolution consults at most two candidates**, in a fixed order, and **never silently falls back**
+  across the developer/end-user boundary.
+- **Every failure is loud** and offers exactly one next action.
+
+## Confirmed decisions
+
+1. **Rename** `mrdViz.pythonPath` → **`mrdViz.backendPath`** (accepts an interpreter *or* a binary
+   path). Read the old `mrdViz.pythonPath` for backward compatibility.
+2. **Dev convenience gated on `context.extensionMode === Development`** (set by VS Code for the F5
+   host, not derived from any setting). Repo `backend/.venv` is consulted only in Development mode
+   and only when `backendPath` is unset.
+3. **`backendPath` is `"scope": "machine"`**, and provisioning/selection persists the resolved path
+   via `ConfigurationTarget.Global` (which routes to host user settings or the container's remote
+   settings automatically). This structurally prevents the workspace→container path leak and keeps
+   the path out of Settings Sync.
+4. **Old-glibc Linux binary is an odin dependency**, not a bespoke mrd-viz build. Until odin ships a
+   compatible build, old-glibc Linux end users hit the fail-loud → guided-setup/override path.
+
+## Resolution model
+
+```
+Production (installed VSIX):
+    1. backendPath set?  -> probe; ok -> use;  fail -> FAIL LOUD (no fallback)
+    2. bundled binary?   -> probe; ok -> use;  fail/absent -> FAIL LOUD (offer recovery)
+
+Development (F5 host):
+    1. backendPath set?  -> probe; ok -> use;  fail -> FAIL LOUD (no fallback)
+    (dev) backendPath UNSET -> repo backend/.venv -> probe; ok -> use
+    2. bundled binary?   -> probe; ok -> use;  fail/absent -> FAIL LOUD (offer recovery)
+```
+
+"Probe" = run the candidate with `--version` under a short timeout and require exit code 0 (the
+existing `validateBackend`). Both delivery forms expose the identical CLI
+([`cli.py`](../backend/src/mrd_viz/cli.py)); binary uses `baseArgs: []`, interpreter uses
+`baseArgs: ['-m', 'mrd_viz.cli']`.
+
+---
+
+## Phase 0 — Preconditions
+
+- **P0.1 (external, odin):** track the old-glibc Linux binary as an upstream odin dependency. Do
+  **not** add a custom low-glibc build to mrd-viz. The deterministic resolver degrades gracefully
+  (fail loud + offer override/guided setup) where no compatible binary exists, so this does not
+  block the rest of the work — it only bounds which platforms get the zero-config default.
+- **P0.2 CLI parity test:** assert `python -m mrd_viz.cli --version` and the built binary agree, so
+  the two delivery forms can't diverge silently. Lives with the backend tests.
+
+## Phase 1 — Settings schema (`package.json`)
+
+- Add `mrdViz.backendPath`:
+  - `"type": "string"`, **no default** (unset must mean "unset", fixing the `default: "python"`
+    trap), `"scope": "machine"`.
+  - `markdownDescription`: "Developer override — path to a Python interpreter (runs
+    `python -m mrd_viz.cli`) or a prebuilt backend binary. Leave unset to use the backend bundled
+    with the extension."
+- Keep `mrdViz.pythonPath` declared but mark it deprecated (`markdownDeprecationMessage`) and read it
+  as a fallback for one release.
+- No change to `mrdViz.maxThumbnails` / `mrdViz.backendTimeoutMs`.
+
+## Phase 2 — Resolver rewrite ([`backendResolver.ts`](../extension/mrd-viz/src/backendResolver.ts))
+
+- Replace `backendCandidates()` (5 candidates) with an ordered builder that takes
+  `context.extensionMode`:
+  - `getConfiguredBackendPath()`: read `backendPath` (then legacy `pythonPath`) via `get()`; missing
+    → `undefined`. Classify interpreter vs. binary by basename (`mrd-viz` / `mrd-viz.exe`) or
+    extension, producing `baseArgs` accordingly.
+  - Bundled binary via existing `bundledBinaryPath()`.
+  - Dev-only: `developmentVenvPython()` **only** when `extensionMode === Development` and
+    `backendPath` is unset.
+- **No cross-tier fallback:** if `backendPath` is set and its probe fails, return
+  `{ ok:false, tried:[thatAttempt] }` — do not try the binary. Encode the failing tier so the UI can
+  tailor the message.
+- Delete the managed-venv candidate and the `python`/`python3` PATH candidates from resolution.
+- Keep `validateBackend`, `invalidateBackendCache`, and the `BackendAttempt` shape.
+
+## Phase 3 — Fail-loud UX
+
+- `getMrdBackendMissingHtml` ([`webviewHtml.ts`](../extension/mrd-viz/src/webviewHtml.ts)) grows two
+  shapes, each with one action:
+  - **Developer override broken:** show the configured path + probe error → "Select Python
+    Interpreter…".
+  - **End user, no runnable binary:** (unsupported platform / missing binary) → one recovery:
+    guided setup.
+- `provisionManagedBackend` ([`extension.ts`](../extension/mrd-viz/src/extension.ts)) on success
+  **writes the venv path to `backendPath` (`ConfigurationTarget.Global`)**, collapsing the managed
+  venv into tier 1. It stays a *recovery command*, not a resolver candidate.
+- `selectInterpreter` writes `backendPath` (`Global`) and **drops** the manual Workspace/
+  WorkspaceFolder clearing (unnecessary once the setting is machine-scoped).
+- The re-resolve-after-setup flow in [`mrdEditorProvider.ts`](../extension/mrd-viz/src/mrdEditorProvider.ts)
+  is unchanged in shape.
+
+## Phase 4 — Environments
+
+- **Dev container:** stop hard-coding `mrdViz.pythonPath` in
+  [`.devcontainer/mrd-viz/devcontainer.json`](../../.devcontainer/mrd-viz/devcontainer.json). Let
+  `postCreate` provisioning write `backendPath` to the container's remote settings (verify how the
+  installed VS Code applies dev-container settings vs. `machine` scope during implementation).
+- **F5 contributors:** covered by the Development-mode repo-`.venv` gate; no committed workspace
+  setting needed.
+
+## Phase 5 — Cleanup & docs
+
+- Remove dead resolver code (managed-venv candidate, PATH candidates; keep helpers still used by
+  provisioning).
+- Update the "current state" half of [BACKEND_INSTALL_MODES.md](BACKEND_INSTALL_MODES.md) to match,
+  plus [DEVCONTAINER.md](DEVCONTAINER.md) and the runbooks.
+- Tests: resolver unit tests for the two-tier order, the no-fallback rule, and the Development gate;
+  keep the command-registration test in
+  [`extension.test.ts`](../extension/mrd-viz/src/test/extension.test.ts).
+
+## Phase 6 — Verification matrix
+
+| Scenario | Expected |
+|---|---|
+| Installed VSIX, no Python on host | bundled binary runs (zero config) |
+| `backendPath` set but broken | fail loud; **no** silent binary use |
+| Dev container | uses the configured/provisioned container venv |
+| F5 from source, `backendPath` unset | uses repo `backend/.venv` (Development gate) |
+| Old-glibc Linux, no odin binary yet | fail loud → guided setup / override |
+| Workspace `.vscode/settings.json` sets a path | ignored (machine scope) — no container leak |
+
+## Suggested PR sequencing (small, reviewable)
+
+1. **Schema + resolver core** (Phases 1–2): rename to `backendPath`, machine scope, two-tier
+   resolver, no-fallback, dev gate. Legacy `pythonPath` read retained.
+2. **Fail-loud UX + persistence** (Phase 3): tailored missing-backend pages; provisioning/selection
+   persist `backendPath`; drop scope-clearing.
+3. **Environments + docs + tests** (Phases 4–5): dev container change, doc updates, resolver tests.
+
+## Open items to confirm before/while building
+
+- Exact interpreter-vs-binary classification for `backendPath` (basename heuristic vs. an explicit
+  companion setting).
+- Empirical check of dev-container settings application vs. `machine` scope (Phase 4).
+- How long to retain the deprecated `mrdViz.pythonPath` read.

--- a/mrd-viz/docs/DEVCONTAINER.md
+++ b/mrd-viz/docs/DEVCONTAINER.md
@@ -16,7 +16,7 @@ Run MRD Viz inside a reproducible dev container: Python 3.12 + the `mrd_viz` bac
 
 ## 2. One-time setup
 
-`postCreate` already provisions the backend virtualenv at `~/.venvs/mrd-viz` and `mrdViz.pythonPath` points at it, so opening a `.mrd` file works out of the box. To build and install the **MRD Viz extension** itself — and to (re)run the backend install if the automatic step was skipped or failed on a restricted network — run from the container's integrated terminal:
+`postCreate` already provisions the backend virtualenv at `~/.venvs/mrd-viz` and `mrdViz.backendPath` points at it, so opening a `.mrd` file works out of the box. To build and install the **MRD Viz extension** itself — and to (re)run the backend install if the automatic step was skipped or failed on a restricted network — run from the container's integrated terminal:
 
 ```bash
 just mrd-viz-container-setup
@@ -58,9 +58,9 @@ If your feed requires authentication, add the appropriate `_authToken`/credentia
 
 ## Backend error: a host path or `spawn ... ENOENT`
 
-If opening a `.mrd` file fails and the **Running:** line in the error shows a **host path** (e.g. a Windows `...\.venv\Scripts\python.exe`) instead of `/home/vscode/.venvs/mrd-viz/bin/python`, a workspace `.vscode/settings.json` is overriding the container's interpreter. Workspace settings are bind-mounted into the container and outrank the dev container's setting, so a host `mrdViz.pythonPath` leaks in and the Windows executable doesn't exist in Linux (`ENOENT`).
+If opening a `.mrd` file fails and the **Running:** line in the error shows a **host path** (e.g. a Windows `...\.venv\Scripts\python.exe`) instead of `/home/vscode/.venvs/mrd-viz/bin/python`, a host interpreter path is leaking into the container. `mrdViz.backendPath` is **machine-scoped**, so it cannot be set from a committed workspace `.vscode/settings.json` and cannot leak across the host/container boundary — a leak today comes only from a legacy, deprecated `mrdViz.pythonPath` left in workspace settings.
 
-Fix: remove `mrdViz.pythonPath` from the workspace `.vscode/settings.json`, then reload the window. Keep any host-specific value in your **User** settings instead so it doesn't leak into the container.
+Fix: remove any `mrdViz.pythonPath` from the workspace `.vscode/settings.json`, then reload the window. Point the container at its interpreter with `mrdViz.backendPath` in the container's remote (or your **User**) settings instead; because it is machine-scoped it stays per-machine and never leaks.
 
 ## Notes
 

--- a/mrd-viz/docs/DEVCONTAINER.md
+++ b/mrd-viz/docs/DEVCONTAINER.md
@@ -41,20 +41,37 @@ Double-click any `.mrd` file, or run **MRD Viz: Open File** from the Command Pal
 
 ## Restricted / corporate networks
 
-Some corporate networks block direct access to the **public npm registry** (`registry.npmjs.org`) and require an internal mirror instead. Symptom: the container build or `just mrd-viz-container-setup` fails with an `npm` **TLS handshake failure** to `registry.npmjs.org`. (PyPI is typically unaffected, so the backend install still works.)
+Some corporate networks block direct access to the **public npm registry** (`registry.npmjs.org`) **and the public PyPI** (`pypi.org` / `files.pythonhosted.org`), requiring an internal mirror instead. Symptoms: the container build, `postCreate`, or `just mrd-viz-container-setup` fails with an `npm` **TLS handshake failure**, or `pip` fails with `SSL: SSLV3_ALERT_HANDSHAKE_FAILURE` while resolving packages.
 
-To fix it, point the container's npm at your organization's feed with a **git-ignored** `.npmrc`:
+### Automatic handling (default)
 
-1. Find your feed on the host: `npm config get registry`.
-2. Create `mrd-viz/extension/mrd-viz/.npmrc` (git-ignored) with:
+Both blockers are handled for you by [`.devcontainer/mrd-viz/select-pkg-index.sh`](../../.devcontainer/mrd-viz/select-pkg-index.sh), which `postCreate` and `just mrd-viz-container-setup` source before any `pip`/`npm` call. It walks an ordered **candidate ladder** — the Microsoft-internal mirror first, the public registry as fallback — probes each, and exports `PIP_INDEX_URL` / `npm_config_registry` to the first that responds:
 
-   ```ini
-   registry=https://your-org-feed.example/npm/
-   ```
+- **Microsoft-internal devs** (on the corp network) get the internal mirror automatically.
+- **External contributors** (internal mirror unreachable) fall back to the public registry automatically.
 
-3. Run `just mrd-viz-container-setup` again.
+The candidate lists live in [`.devcontainer/mrd-viz/devcontainer.json`](../../.devcontainer/mrd-viz/devcontainer.json) under `remoteEnv`, so the internal feed is discoverable in a committed file rather than a hidden dotfile:
 
-If your feed requires authentication, add the appropriate `_authToken`/credential-provider lines (same as your host `.npmrc`). This file is git-ignored so the internal URL is never committed.
+```jsonc
+"remoteEnv": {
+  "MRD_PIP_INDEX_URLS": "https://packagefeedproxy.microsoft.io/pypi/simple/ https://pypi.org/simple/",
+  "MRD_NPM_REGISTRIES": "https://packagefeedproxy.microsoft.io/npm/ https://registry.npmjs.org/"
+}
+```
+
+### Manual override
+
+If probing picks the wrong feed, or you run the setup outside the container, force a feed by exporting the vars pip and npm read natively, then re-run `just mrd-viz-container-setup`:
+
+```bash
+export PIP_INDEX_URL="https://packagefeedproxy.microsoft.io/pypi/simple/"
+export npm_config_registry="https://packagefeedproxy.microsoft.io/npm/"
+```
+
+The setup scripts print these exact `export` lines if no candidate is reachable. An explicit `PIP_INDEX_URL` / `npm_config_registry` always wins over the ladder. Find your own feed URLs on the host with `pip config get global.index-url` and `npm config get registry`. If a feed requires authentication, add the appropriate credential (e.g. a git-ignored `~/.netrc`, or `_authToken` in a git-ignored user `~/.npmrc`) — never commit credentials.
+
+> A git-ignored project `.npmrc` (`mrd-viz/extension/mrd-viz/.npmrc` with `registry=…`) still works and takes precedence for npm, but is no longer required now that the ladder exports `npm_config_registry` automatically.
+
 
 ## Backend error: a host path or `spawn ... ENOENT`
 

--- a/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
+++ b/mrd-viz/docs/PACKAGING_AND_INSTALL_RUNBOOK.md
@@ -96,7 +96,7 @@ You can also install from the UI: **Extensions view → Views and More Actions (
 
 ## 6. Set Up the Backend (Required to Open Files)
 
-Installing the VSIX makes the extension available in every window, but rendering `.mrd` files needs the `mrd_viz` Python backend on the machine. The repo-relative `.venv` auto-detection only works when running from source (the F5 dev host) — an **installed** extension must be pointed at the interpreter explicitly via `mrdViz.pythonPath`.
+Installing the VSIX makes the extension available in every window, but rendering `.mrd` files needs the `mrd_viz` Python backend on the machine. The repo-relative `.venv` auto-detection only works when running from source (the F5 dev host), and a locally built VSIX doesn't bundle the backend binary — so an **installed** extension must be pointed at the interpreter explicitly via `mrdViz.backendPath`.
 
 You only need **steps 1–3** of the [Official Extension Development Runbook](OFFICIAL_EXT_DEV_RUNBOOK.md); they are reproduced here for convenience.
 
@@ -146,17 +146,17 @@ The printed path is the value you need next:
 
 ### 6c. Point the extension at that interpreter
 
-Set `mrdViz.pythonPath` to the path from 6b — via **Settings → search "mrdViz: Python Path"**, or in `settings.json`:
+Set `mrdViz.backendPath` to the path from 6b — via **Settings → search "mrdViz: Backend Path"**, or in `settings.json`:
 
 ```json
 {
-  "mrdViz.pythonPath": "<repo-root>/mrd-viz/backend/.venv/bin/python"
+  "mrdViz.backendPath": "<repo-root>/mrd-viz/backend/.venv/bin/python"
 }
 ```
 
-> **Why set this explicitly?** If `mrdViz.pythonPath` is empty, the extension falls back to a bare `python` on `PATH`. On machines that only have `python3` (common on Linux/macOS), that lookup fails and you get a backend error even though Python is installed. Pointing `mrdViz.pythonPath` at the venv interpreter avoids the `python` vs `python3` ambiguity entirely.
+> **Why set this explicitly?** A locally built VSIX doesn't bundle the backend binary, and there is no `python`/`python3`-on-`PATH` fallback, so an installed extension has no backend until `mrdViz.backendPath` points at an interpreter that has `mrd_viz`.
 
-> **Set this in User settings, not Workspace settings, if you also use the dev container.** A workspace `.vscode/settings.json` is bind-mounted into the dev container, so a host path set there (e.g. a Windows `...\.venv\Scripts\python.exe`) leaks into the container and overrides its Linux interpreter — producing a `spawn ... ENOENT` backend error. The dev container sets its own `mrdViz.pythonPath`; keeping the host value in **User** settings prevents the two from colliding.
+> **`mrdViz.backendPath` is machine-scoped**, so it can't be set in a committed workspace `.vscode/settings.json` and never leaks into the dev container (the container sets its own value in its remote settings). This closes the old `spawn ... ENOENT` class of errors.
 
 ### 6d. Open a file
 
@@ -180,5 +180,5 @@ code --uninstall-extension ismrmrd.mrd-viz
 ## Notes
 
 - **Publisher / icon:** `publisher` is set to `ismrmrd` so packaging succeeds; an `icon` is optional (only a warning). Both matter only when publishing to the Marketplace, which is out of scope for local installs.
-- **Backend requirement:** installing the VSIX makes the extension available everywhere, but rendering requires the `mrd_viz` Python backend and `mrdViz.pythonPath` pointed at its interpreter (section 6). Distributing/provisioning the backend automatically is tracked separately.
+- **Backend requirement:** installing the VSIX makes the extension available everywhere, but rendering requires the `mrd_viz` Python backend and `mrdViz.backendPath` pointed at its interpreter (section 6). Distributing/provisioning the backend automatically is tracked separately.
 - **Relation to publishing:** to later publish to the Marketplace, register the `ismrmrd` publisher and run `vsce publish`; the packaging config here (`.vscodeignore`, manifest metadata) is the same foundation.

--- a/mrd-viz/docs/TECHNICAL_DESIGN.md
+++ b/mrd-viz/docs/TECHNICAL_DESIGN.md
@@ -246,7 +246,7 @@ The VS Code extension owns editor registration, process orchestration, and UI pr
 
 - register the custom readonly editor for `.mrd` files
 - expose an explicit `Open in MRD Viewer` command
-- resolve the configured Python executable through `mrdViz.pythonPath`
+- resolve the configured backend through `mrdViz.backendPath`, or fall back to the bundled binary
 - spawn the `mrd-viz` backend CLI with file path and requested operation
 - enforce a stable JSON contract between extension and backend
 - render loading, success, unsupported, and error states in the webview
@@ -503,7 +503,7 @@ The extension should add a small VS Code extension test suite once the custom ed
 
 - activation registers the explicit open command.
 - `.mrd` files can be opened with the `mrd-viz.mrdFile` custom editor view type.
-- `mrdViz.pythonPath` is honored.
+- `mrdViz.backendPath` is honored.
 - backend process errors render the error view rather than crashing the extension host.
 - backend process timeout and cancellation render controlled states.
 - a mocked `open` payload renders a mosaic in the image webview and metadata in the adjacent metadata webview.
@@ -521,7 +521,7 @@ Stage 1 can begin with manual VS Code smoke tests, but the release candidate sho
 - Confirm image count and stream counts match CLI output.
 - Open a known raw `.mrd` file and confirm it shows a raw/acquisition-oriented summary rather than a misleading blank image.
 - Open an invalid file and confirm the error is explicit.
-- Change `mrdViz.pythonPath` to the project `.venv` interpreter and confirm the extension uses it.
+- Change `mrdViz.backendPath` to the project `.venv` interpreter and confirm the extension uses it.
 - Package the extension as a `.vsix` and install it into a separate VS Code instance or profile without local hardcoded paths.
 
 ## Backward Compatibility and Format Risk

--- a/mrd-viz/extension/mrd-viz/README.md
+++ b/mrd-viz/extension/mrd-viz/README.md
@@ -15,13 +15,13 @@ MRD Viz relies on a Python backend (the `mrd_viz` package) to read `.mrd` files.
 - Python 3.12
 - The `mrd_viz` backend installed into an environment the extension can find.
 
-Point the extension at the interpreter with the `mrdViz.pythonPath` setting (see below). During local development the extension also auto-detects a virtual environment at `mrd-viz/backend/.venv`.
+Point the extension at the interpreter with the `mrdViz.backendPath` setting (see below). During local development (the F5 dev host) the extension also auto-detects a virtual environment at `mrd-viz/backend/.venv`.
 
 ## Extension Settings
 
 This extension contributes the following settings:
 
-- `mrdViz.pythonPath`: Python executable used to run `python -m mrd_viz.cli`. Set this to the backend environment's interpreter.
+- `mrdViz.backendPath`: Path to a Python interpreter (runs `python -m mrd_viz.cli`) or a prebuilt `mrd-viz` binary. Leave unset to use the backend bundled with the extension.
 - `mrdViz.maxThumbnails`: Maximum number of image thumbnails requested for the initial view (default `128`).
 - `mrdViz.backendTimeoutMs`: Timeout in milliseconds for a single backend process (default `30000`).
 

--- a/mrd-viz/extension/mrd-viz/package.json
+++ b/mrd-viz/extension/mrd-viz/package.json
@@ -50,10 +50,15 @@
     "configuration": {
       "title": "MRD Viz",
       "properties": {
+        "mrdViz.backendPath": {
+          "type": "string",
+          "scope": "machine",
+          "markdownDescription": "Developer override for the MRD Viz backend. Provide a path to a Python interpreter (runs `python -m mrd_viz.cli`) or to a prebuilt `mrd-viz` backend binary. **Leave unset to use the backend bundled with the extension.** Machine-scoped so an absolute path is never committed to a workspace or synced between machines."
+        },
         "mrdViz.pythonPath": {
           "type": "string",
-          "default": "python",
-          "markdownDescription": "Python executable used to run `python -m mrd_viz.cli`. Set this to the backend virtual environment interpreter when needed."
+          "markdownDescription": "Deprecated: use `#mrdViz.backendPath#` instead.",
+          "markdownDeprecationMessage": "Deprecated: use `#mrdViz.backendPath#` instead. An explicitly set value is still honored for backward compatibility."
         },
         "mrdViz.maxThumbnails": {
           "type": "number",

--- a/mrd-viz/extension/mrd-viz/package.json
+++ b/mrd-viz/extension/mrd-viz/package.json
@@ -55,11 +55,6 @@
           "scope": "machine",
           "markdownDescription": "Developer override for the MRD Viz backend. Provide a path to a Python interpreter (runs `python -m mrd_viz.cli`) or to a prebuilt `mrd-viz` backend binary. **Leave unset to use the backend bundled with the extension.** Machine-scoped so an absolute path is never committed to a workspace or synced between machines."
         },
-        "mrdViz.pythonPath": {
-          "type": "string",
-          "markdownDescription": "Deprecated: use `#mrdViz.backendPath#` instead.",
-          "markdownDeprecationMessage": "Deprecated: use `#mrdViz.backendPath#` instead. An explicitly set value is still honored for backward compatibility."
-        },
         "mrdViz.maxThumbnails": {
           "type": "number",
           "default": 128,

--- a/mrd-viz/extension/mrd-viz/src/backendConstants.ts
+++ b/mrd-viz/extension/mrd-viz/src/backendConstants.ts
@@ -26,5 +26,12 @@ export const PYTHON_MODULE_ARGS = ['-m', 'mrd_viz.cli'] as const;
 /** The pip distribution name for the backend (not yet published to PyPI). */
 export const PYPI_PACKAGE_NAME = 'mrd-viz';
 
+/**
+ * Base name of the standalone backend binary (the PyInstaller output bundled in the VSIX at
+ * `media/backend/`). Kept here so a rename of the backend/binary touches one place rather than
+ * scattered string literals in the resolver.
+ */
+export const BACKEND_BINARY_NAME = 'mrd-viz';
+
 /** Interpreter commands tried, in order, when discovering a Python to build the managed venv. */
 export const PROVISIONING_PYTHON_CANDIDATES = ['python3.12', 'python3', 'python'] as const;

--- a/mrd-viz/extension/mrd-viz/src/backendConstants.ts
+++ b/mrd-viz/extension/mrd-viz/src/backendConstants.ts
@@ -1,0 +1,30 @@
+// Centralized timeouts, buffer sizes, and backend invocation constants so the several subprocess
+// call sites (resolver probe, backend run, Python-version probe, provisioning) don't drift.
+
+/** Default per-process backend timeout. Must match the `mrdViz.backendTimeoutMs` default in package.json. */
+export const BACKEND_TIMEOUT_MS_DEFAULT = 30_000;
+
+/** Bounds applied to the configured timeout when probing a candidate with `--version`. */
+export const PROBE_TIMEOUT_MS_MIN = 1_000;
+export const PROBE_TIMEOUT_MS_MAX = 15_000;
+
+/** Timeout for the quick `sys.version_info` probe used to find a provisioning interpreter. */
+export const PYTHON_VERSION_PROBE_TIMEOUT_MS = 10_000;
+
+/** Timeout for one provisioning step (venv creation / pip install); pip installs can be slow. */
+export const PROVISIONING_STEP_TIMEOUT_MS = 10 * 60 * 1_000;
+
+/** stdout/stderr buffer for a backend payload response (base64 PNGs can be large). */
+export const BACKEND_RESPONSE_MAX_BUFFER_BYTES = 64 * 1024 * 1024;
+
+/** stdout/stderr buffer for a provisioning step's logs. */
+export const PROVISIONING_LOG_MAX_BUFFER_BYTES = 10 * 1024 * 1024;
+
+/** Leading args that invoke the backend CLI through a Python interpreter. */
+export const PYTHON_MODULE_ARGS = ['-m', 'mrd_viz.cli'] as const;
+
+/** The pip distribution name for the backend (not yet published to PyPI). */
+export const PYPI_PACKAGE_NAME = 'mrd-viz';
+
+/** Interpreter commands tried, in order, when discovering a Python to build the managed venv. */
+export const PROVISIONING_PYTHON_CANDIDATES = ['python3.12', 'python3', 'python'] as const;

--- a/mrd-viz/extension/mrd-viz/src/backendResolver.ts
+++ b/mrd-viz/extension/mrd-viz/src/backendResolver.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
-import { PROBE_TIMEOUT_MS_MAX, PROBE_TIMEOUT_MS_MIN, PYTHON_MODULE_ARGS } from './backendConstants';
+import { BACKEND_BINARY_NAME, PROBE_TIMEOUT_MS_MAX, PROBE_TIMEOUT_MS_MIN, PYTHON_MODULE_ARGS } from './backendConstants';
 import { runProcess } from './subprocess';
 
 /** How a backend candidate was selected. Drives tailored failure messaging in the webview. */
@@ -54,6 +54,13 @@ export async function resolveBackend(context: vscode.ExtensionContext, validatio
 		developmentVenvPath: developmentVenvPython(context),
 		isDevelopment: context.extensionMode === vscode.ExtensionMode.Development,
 	});
+
+	// No override and no bundled binary for this platform means there is nothing to probe and no way
+	// the extension can work. Surface that explicitly rather than returning an empty `tried` list the
+	// webview cannot explain.
+	if (candidates.length === 0) {
+		return { ok: false, tried: [noBackendAvailableAttempt()] };
+	}
 
 	const tried: BackendAttempt[] = [];
 	for (const candidate of candidates) {
@@ -124,6 +131,18 @@ export function planBackendCandidates(inputs: BackendCandidateInputs): ResolvedB
 	return candidates;
 }
 
+/**
+ * The failure surfaced when {@link planBackendCandidates} yields nothing: no `mrdViz.backendPath`
+ * override and no bundled binary shipped for this platform. Gives the webview a concrete, actionable
+ * message (and its setup buttons) instead of an empty attempt list.
+ */
+function noBackendAvailableAttempt(): BackendAttempt {
+	return {
+		source: 'no backend available',
+		detail: `No ${BACKEND_PATH_SETTING} is set and no bundled backend was shipped for this platform (${process.platform}-${process.arch}). Use “Set Up Backend Automatically…” or “Select Python Interpreter…” below to provide one.`,
+	};
+}
+
 /** Build the override candidate, treating an `mrd-viz` executable as a binary and anything else as an interpreter. */
 function configuredBackend(configuredPath: string): ResolvedBackend {
 	const baseArgs = looksLikeBackendBinary(configuredPath) ? [] : [...PYTHON_MODULE_ARGS];
@@ -133,7 +152,7 @@ function configuredBackend(configuredPath: string): ResolvedBackend {
 /** Whether a configured path points at the standalone backend binary rather than a Python interpreter. */
 function looksLikeBackendBinary(configuredPath: string): boolean {
 	const base = path.basename(configuredPath).toLowerCase();
-	return base === 'mrd-viz' || base === 'mrd-viz.exe';
+	return base === BACKEND_BINARY_NAME || base === `${BACKEND_BINARY_NAME}.exe`;
 }
 
 interface ProbeResult {
@@ -206,7 +225,7 @@ function pythonExecutableRelative(): string {
 }
 
 function bundledBinaryPath(context: vscode.ExtensionContext): string | undefined {
-	const name = process.platform === 'win32' ? 'mrd-viz.exe' : 'mrd-viz';
+	const name = process.platform === 'win32' ? `${BACKEND_BINARY_NAME}.exe` : BACKEND_BINARY_NAME;
 	const candidate = path.join(context.extensionUri.fsPath, 'media', 'backend', name);
 	return existsSync(candidate) ? candidate : undefined;
 }

--- a/mrd-viz/extension/mrd-viz/src/backendResolver.ts
+++ b/mrd-viz/extension/mrd-viz/src/backendResolver.ts
@@ -12,6 +12,8 @@ export interface ResolvedBackend {
 	baseArgs: string[];
 	source: string;
 	kind: BackendKind;
+	/** For an override candidate, which setting supplied the path (`mrdViz.backendPath` or legacy `mrdViz.pythonPath`). */
+	settingKey?: string;
 }
 
 /** A candidate that was probed but rejected, plus the reason its `--version` probe failed. */
@@ -19,6 +21,8 @@ export interface BackendAttempt {
 	source: string;
 	/** Which tier this candidate belonged to, so the UI can distinguish a broken override from a missing binary. */
 	kind?: BackendKind;
+	/** For an override attempt, the setting that supplied the path, so the UI points at the right one. */
+	settingKey?: string;
 	/** Concise, webview-friendly failure reason (last lines of probe stderr, or the spawn error). */
 	detail?: string;
 	/** Complete captured probe output, logged in full to the output channel (never truncated). */
@@ -45,8 +49,10 @@ export async function resolveBackend(context: vscode.ExtensionContext, validatio
 		return { ok: true, backend: cachedBackend };
 	}
 
+	const configured = getConfiguredBackendPath();
 	const candidates = planBackendCandidates({
-		configuredPath: getConfiguredBackendPath(),
+		configuredPath: configured?.path,
+		configuredSettingKey: configured?.settingKey,
 		bundledBinaryPath: bundledBinaryPath(context),
 		developmentVenvPath: developmentVenvPython(context),
 		isDevelopment: context.extensionMode === vscode.ExtensionMode.Development,
@@ -59,36 +65,41 @@ export async function resolveBackend(context: vscode.ExtensionContext, validatio
 			cachedBackend = candidate;
 			return { ok: true, backend: candidate };
 		}
-		tried.push({ source: candidate.source, kind: candidate.kind, detail: probe.detail, detailFull: probe.detailFull });
+		tried.push({ source: candidate.source, kind: candidate.kind, settingKey: candidate.settingKey, detail: probe.detail, detailFull: probe.detailFull });
 	}
 
 	return { ok: false, tried };
 }
 
 const PYTHON_MODULE_ARGS = ['-m', 'mrd_viz.cli'];
+const BACKEND_PATH_SETTING = 'mrdViz.backendPath';
+const LEGACY_PATH_SETTING = 'mrdViz.pythonPath';
 
 /**
  * The developer override, if set: the machine-scoped `mrdViz.backendPath`, or an explicitly set
- * (non-default) legacy `mrdViz.pythonPath` for backward compatibility. Returns undefined when the
- * user has configured nothing — the signal that this is an end-user install that should use the
- * bundled backend.
+ * (non-default) legacy `mrdViz.pythonPath` for backward compatibility. Returns the path plus which
+ * setting supplied it (so messaging points at the right one), or undefined when the user has
+ * configured nothing — the signal that this is an end-user install that should use the bundled
+ * backend.
  */
-export function getConfiguredBackendPath(): string | undefined {
+export function getConfiguredBackendPath(): { path: string; settingKey: string } | undefined {
 	const config = vscode.workspace.getConfiguration('mrdViz');
 	const backendPath = config.get<string>('backendPath')?.trim();
 	if (backendPath) {
-		return backendPath;
+		return { path: backendPath, settingKey: BACKEND_PATH_SETTING };
 	}
 	// Back-compat: honor an explicitly set legacy mrdViz.pythonPath (ignoring any default value).
 	const legacy = config.inspect<string>('pythonPath');
 	const legacyValue = (legacy?.workspaceFolderValue ?? legacy?.workspaceValue ?? legacy?.globalValue)?.trim();
-	return legacyValue || undefined;
+	return legacyValue ? { path: legacyValue, settingKey: LEGACY_PATH_SETTING } : undefined;
 }
 
 /** Inputs to {@link planBackendCandidates}; plain data so the ordering logic stays pure and testable. */
 export interface BackendCandidateInputs {
 	/** Developer override path (interpreter or binary), or undefined when unset. */
 	configuredPath?: string;
+	/** Which setting supplied `configuredPath` (`mrdViz.backendPath` or legacy `mrdViz.pythonPath`). */
+	configuredSettingKey?: string;
 	/** Path to the bundled binary if present in the VSIX, else undefined. */
 	bundledBinaryPath?: string;
 	/** Path to the repo `backend/.venv` interpreter if present, else undefined. */
@@ -107,7 +118,7 @@ export interface BackendCandidateInputs {
  */
 export function planBackendCandidates(inputs: BackendCandidateInputs): ResolvedBackend[] {
 	if (inputs.configuredPath) {
-		return [configuredBackend(inputs.configuredPath)];
+		return [configuredBackend(inputs.configuredPath, inputs.configuredSettingKey)];
 	}
 
 	const candidates: ResolvedBackend[] = [];
@@ -131,9 +142,9 @@ export function planBackendCandidates(inputs: BackendCandidateInputs): ResolvedB
 }
 
 /** Build the override candidate, treating an `mrd-viz` executable as a binary and anything else as an interpreter. */
-function configuredBackend(configuredPath: string): ResolvedBackend {
+function configuredBackend(configuredPath: string, settingKey: string = BACKEND_PATH_SETTING): ResolvedBackend {
 	const baseArgs = looksLikeBackendBinary(configuredPath) ? [] : PYTHON_MODULE_ARGS;
-	return { command: configuredPath, baseArgs, source: `mrdViz.backendPath setting (${configuredPath})`, kind: 'override' };
+	return { command: configuredPath, baseArgs, source: `${settingKey} setting (${configuredPath})`, kind: 'override', settingKey };
 }
 
 /** Whether a configured path points at the standalone backend binary rather than a Python interpreter. */

--- a/mrd-viz/extension/mrd-viz/src/backendResolver.ts
+++ b/mrd-viz/extension/mrd-viz/src/backendResolver.ts
@@ -1,7 +1,10 @@
-import { execFile, type ExecFileException } from 'node:child_process';
+import { type ExecFileException } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
+
+import { PROBE_TIMEOUT_MS_MAX, PROBE_TIMEOUT_MS_MIN, PYTHON_MODULE_ARGS } from './backendConstants';
+import { runProcess } from './subprocess';
 
 /** How a backend candidate was selected. Drives tailored failure messaging in the webview. */
 export type BackendKind = 'override' | 'bundled' | 'development';
@@ -71,7 +74,6 @@ export async function resolveBackend(context: vscode.ExtensionContext, validatio
 	return { ok: false, tried };
 }
 
-const PYTHON_MODULE_ARGS = ['-m', 'mrd_viz.cli'];
 const BACKEND_PATH_SETTING = 'mrdViz.backendPath';
 const LEGACY_PATH_SETTING = 'mrdViz.pythonPath';
 
@@ -82,7 +84,7 @@ const LEGACY_PATH_SETTING = 'mrdViz.pythonPath';
  * configured nothing — the signal that this is an end-user install that should use the bundled
  * backend.
  */
-export function getConfiguredBackendPath(): { path: string; settingKey: string } | undefined {
+function getConfiguredBackendPath(): { path: string; settingKey: string } | undefined {
 	const config = vscode.workspace.getConfiguration('mrdViz');
 	const backendPath = config.get<string>('backendPath')?.trim();
 	if (backendPath) {
@@ -125,7 +127,7 @@ export function planBackendCandidates(inputs: BackendCandidateInputs): ResolvedB
 	if (inputs.isDevelopment && inputs.developmentVenvPath) {
 		candidates.push({
 			command: inputs.developmentVenvPath,
-			baseArgs: PYTHON_MODULE_ARGS,
+			baseArgs: [...PYTHON_MODULE_ARGS],
 			source: `development environment (${inputs.developmentVenvPath})`,
 			kind: 'development',
 		});
@@ -143,7 +145,7 @@ export function planBackendCandidates(inputs: BackendCandidateInputs): ResolvedB
 
 /** Build the override candidate, treating an `mrd-viz` executable as a binary and anything else as an interpreter. */
 function configuredBackend(configuredPath: string, settingKey: string = BACKEND_PATH_SETTING): ResolvedBackend {
-	const baseArgs = looksLikeBackendBinary(configuredPath) ? [] : PYTHON_MODULE_ARGS;
+	const baseArgs = looksLikeBackendBinary(configuredPath) ? [] : [...PYTHON_MODULE_ARGS];
 	return { command: configuredPath, baseArgs, source: `${settingKey} setting (${configuredPath})`, kind: 'override', settingKey };
 }
 
@@ -161,22 +163,13 @@ interface ProbeResult {
 	detailFull?: string;
 }
 
-function validateBackend(candidate: ResolvedBackend, timeoutMs: number): Promise<ProbeResult> {
-	const timeout = Math.min(Math.max(timeoutMs, 1000), 15000);
-	return new Promise(resolve => {
-		execFile(
-			candidate.command,
-			[...candidate.baseArgs, '--version'],
-			{ timeout, windowsHide: true },
-			(error, _stdout, stderr) => {
-				if (!error) {
-					resolve({ ok: true });
-					return;
-				}
-				resolve({ ok: false, detail: describeProbeFailure(error, stderr), detailFull: fullProbeFailure(error, stderr) });
-			},
-		);
-	});
+async function validateBackend(candidate: ResolvedBackend, timeoutMs: number): Promise<ProbeResult> {
+	const timeout = Math.min(Math.max(timeoutMs, PROBE_TIMEOUT_MS_MIN), PROBE_TIMEOUT_MS_MAX);
+	const { error, stderr } = await runProcess(candidate.command, [...candidate.baseArgs, '--version'], { timeoutMs: timeout });
+	if (!error) {
+		return { ok: true };
+	}
+	return { ok: false, detail: describeProbeFailure(error, stderr), detailFull: fullProbeFailure(error, stderr) };
 }
 
 /**

--- a/mrd-viz/extension/mrd-viz/src/backendResolver.ts
+++ b/mrd-viz/extension/mrd-viz/src/backendResolver.ts
@@ -15,8 +15,6 @@ export interface ResolvedBackend {
 	baseArgs: string[];
 	source: string;
 	kind: BackendKind;
-	/** For an override candidate, which setting supplied the path (`mrdViz.backendPath` or legacy `mrdViz.pythonPath`). */
-	settingKey?: string;
 }
 
 /** A candidate that was probed but rejected, plus the reason its `--version` probe failed. */
@@ -24,8 +22,6 @@ export interface BackendAttempt {
 	source: string;
 	/** Which tier this candidate belonged to, so the UI can distinguish a broken override from a missing binary. */
 	kind?: BackendKind;
-	/** For an override attempt, the setting that supplied the path, so the UI points at the right one. */
-	settingKey?: string;
 	/** Concise, webview-friendly failure reason (last lines of probe stderr, or the spawn error). */
 	detail?: string;
 	/** Complete captured probe output, logged in full to the output channel (never truncated). */
@@ -52,10 +48,8 @@ export async function resolveBackend(context: vscode.ExtensionContext, validatio
 		return { ok: true, backend: cachedBackend };
 	}
 
-	const configured = getConfiguredBackendPath();
 	const candidates = planBackendCandidates({
-		configuredPath: configured?.path,
-		configuredSettingKey: configured?.settingKey,
+		configuredPath: getConfiguredBackendPath(),
 		bundledBinaryPath: bundledBinaryPath(context),
 		developmentVenvPath: developmentVenvPython(context),
 		isDevelopment: context.extensionMode === vscode.ExtensionMode.Development,
@@ -68,40 +62,27 @@ export async function resolveBackend(context: vscode.ExtensionContext, validatio
 			cachedBackend = candidate;
 			return { ok: true, backend: candidate };
 		}
-		tried.push({ source: candidate.source, kind: candidate.kind, settingKey: candidate.settingKey, detail: probe.detail, detailFull: probe.detailFull });
+		tried.push({ source: candidate.source, kind: candidate.kind, detail: probe.detail, detailFull: probe.detailFull });
 	}
 
 	return { ok: false, tried };
 }
 
 const BACKEND_PATH_SETTING = 'mrdViz.backendPath';
-const LEGACY_PATH_SETTING = 'mrdViz.pythonPath';
 
 /**
- * The developer override, if set: the machine-scoped `mrdViz.backendPath`, or an explicitly set
- * (non-default) legacy `mrdViz.pythonPath` for backward compatibility. Returns the path plus which
- * setting supplied it (so messaging points at the right one), or undefined when the user has
- * configured nothing — the signal that this is an end-user install that should use the bundled
- * backend.
+ * The developer override, if set: the machine-scoped `mrdViz.backendPath`. Returns undefined when
+ * the user has configured nothing — the signal that this is an end-user install that should use the
+ * bundled backend.
  */
-function getConfiguredBackendPath(): { path: string; settingKey: string } | undefined {
-	const config = vscode.workspace.getConfiguration('mrdViz');
-	const backendPath = config.get<string>('backendPath')?.trim();
-	if (backendPath) {
-		return { path: backendPath, settingKey: BACKEND_PATH_SETTING };
-	}
-	// Back-compat: honor an explicitly set legacy mrdViz.pythonPath (ignoring any default value).
-	const legacy = config.inspect<string>('pythonPath');
-	const legacyValue = (legacy?.workspaceFolderValue ?? legacy?.workspaceValue ?? legacy?.globalValue)?.trim();
-	return legacyValue ? { path: legacyValue, settingKey: LEGACY_PATH_SETTING } : undefined;
+function getConfiguredBackendPath(): string | undefined {
+	return vscode.workspace.getConfiguration('mrdViz').get<string>('backendPath')?.trim() || undefined;
 }
 
 /** Inputs to {@link planBackendCandidates}; plain data so the ordering logic stays pure and testable. */
 export interface BackendCandidateInputs {
 	/** Developer override path (interpreter or binary), or undefined when unset. */
 	configuredPath?: string;
-	/** Which setting supplied `configuredPath` (`mrdViz.backendPath` or legacy `mrdViz.pythonPath`). */
-	configuredSettingKey?: string;
 	/** Path to the bundled binary if present in the VSIX, else undefined. */
 	bundledBinaryPath?: string;
 	/** Path to the repo `backend/.venv` interpreter if present, else undefined. */
@@ -120,7 +101,7 @@ export interface BackendCandidateInputs {
  */
 export function planBackendCandidates(inputs: BackendCandidateInputs): ResolvedBackend[] {
 	if (inputs.configuredPath) {
-		return [configuredBackend(inputs.configuredPath, inputs.configuredSettingKey)];
+		return [configuredBackend(inputs.configuredPath)];
 	}
 
 	const candidates: ResolvedBackend[] = [];
@@ -144,9 +125,9 @@ export function planBackendCandidates(inputs: BackendCandidateInputs): ResolvedB
 }
 
 /** Build the override candidate, treating an `mrd-viz` executable as a binary and anything else as an interpreter. */
-function configuredBackend(configuredPath: string, settingKey: string = BACKEND_PATH_SETTING): ResolvedBackend {
+function configuredBackend(configuredPath: string): ResolvedBackend {
 	const baseArgs = looksLikeBackendBinary(configuredPath) ? [] : [...PYTHON_MODULE_ARGS];
-	return { command: configuredPath, baseArgs, source: `${settingKey} setting (${configuredPath})`, kind: 'override', settingKey };
+	return { command: configuredPath, baseArgs, source: `${BACKEND_PATH_SETTING} setting (${configuredPath})`, kind: 'override' };
 }
 
 /** Whether a configured path points at the standalone backend binary rather than a Python interpreter. */

--- a/mrd-viz/extension/mrd-viz/src/backendResolver.ts
+++ b/mrd-viz/extension/mrd-viz/src/backendResolver.ts
@@ -3,16 +3,22 @@ import { existsSync } from 'node:fs';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
+/** How a backend candidate was selected. Drives tailored failure messaging in the webview. */
+export type BackendKind = 'override' | 'bundled' | 'development';
+
 /** A validated way to invoke the MRD Viz backend: `command` plus fixed leading args. */
 export interface ResolvedBackend {
 	command: string;
 	baseArgs: string[];
 	source: string;
+	kind: BackendKind;
 }
 
 /** A candidate that was probed but rejected, plus the reason its `--version` probe failed. */
 export interface BackendAttempt {
 	source: string;
+	/** Which tier this candidate belonged to, so the UI can distinguish a broken override from a missing binary. */
+	kind?: BackendKind;
 	/** Concise, webview-friendly failure reason (last lines of probe stderr, or the spawn error). */
 	detail?: string;
 	/** Complete captured probe output, logged in full to the output channel (never truncated). */
@@ -39,56 +45,101 @@ export async function resolveBackend(context: vscode.ExtensionContext, validatio
 		return { ok: true, backend: cachedBackend };
 	}
 
+	const candidates = planBackendCandidates({
+		configuredPath: getConfiguredBackendPath(),
+		bundledBinaryPath: bundledBinaryPath(context),
+		developmentVenvPath: developmentVenvPython(context),
+		isDevelopment: context.extensionMode === vscode.ExtensionMode.Development,
+	});
+
 	const tried: BackendAttempt[] = [];
-	for (const candidate of backendCandidates(context)) {
+	for (const candidate of candidates) {
 		const probe = await validateBackend(candidate, validationTimeoutMs);
 		if (probe.ok) {
 			cachedBackend = candidate;
 			return { ok: true, backend: candidate };
 		}
-		tried.push({ source: candidate.source, detail: probe.detail, detailFull: probe.detailFull });
+		tried.push({ source: candidate.source, kind: candidate.kind, detail: probe.detail, detailFull: probe.detailFull });
 	}
 
 	return { ok: false, tried };
 }
 
-export function getConfiguredPythonPath(): string | undefined {
-	const inspected = vscode.workspace.getConfiguration('mrdViz').inspect<string>('pythonPath');
-	const value = inspected?.workspaceFolderValue ?? inspected?.workspaceValue ?? inspected?.globalValue;
-	return value?.trim() || undefined;
+const PYTHON_MODULE_ARGS = ['-m', 'mrd_viz.cli'];
+
+/**
+ * The developer override, if set: the machine-scoped `mrdViz.backendPath`, or an explicitly set
+ * (non-default) legacy `mrdViz.pythonPath` for backward compatibility. Returns undefined when the
+ * user has configured nothing — the signal that this is an end-user install that should use the
+ * bundled backend.
+ */
+export function getConfiguredBackendPath(): string | undefined {
+	const config = vscode.workspace.getConfiguration('mrdViz');
+	const backendPath = config.get<string>('backendPath')?.trim();
+	if (backendPath) {
+		return backendPath;
+	}
+	// Back-compat: honor an explicitly set legacy mrdViz.pythonPath (ignoring any default value).
+	const legacy = config.inspect<string>('pythonPath');
+	const legacyValue = (legacy?.workspaceFolderValue ?? legacy?.workspaceValue ?? legacy?.globalValue)?.trim();
+	return legacyValue || undefined;
 }
 
-function* backendCandidates(context: vscode.ExtensionContext): Generator<ResolvedBackend> {
-	const pythonBaseArgs = ['-m', 'mrd_viz.cli'];
+/** Inputs to {@link planBackendCandidates}; plain data so the ordering logic stays pure and testable. */
+export interface BackendCandidateInputs {
+	/** Developer override path (interpreter or binary), or undefined when unset. */
+	configuredPath?: string;
+	/** Path to the bundled binary if present in the VSIX, else undefined. */
+	bundledBinaryPath?: string;
+	/** Path to the repo `backend/.venv` interpreter if present, else undefined. */
+	developmentVenvPath?: string;
+	/** True when the extension host is the F5 Development host (`ExtensionMode.Development`). */
+	isDevelopment: boolean;
+}
 
-	// 1. Explicit user override.
-	const configured = getConfiguredPythonPath();
-	if (configured) {
-		yield { command: configured, baseArgs: pythonBaseArgs, source: `mrdViz.pythonPath setting (${configured})` };
+/**
+ * Deterministic, two-tier candidate order (see docs/BACKEND_INSTALL_MODES.md):
+ *
+ * - If a developer override is set, it is the ONLY candidate — no silent fallback to the bundled
+ *   binary, so a broken override fails loudly instead of masking a misconfiguration.
+ * - Otherwise (end user / unconfigured) use the bundled binary. In the Development host only, the
+ *   repo `backend/.venv` is tried first so contributors run their live checkout.
+ */
+export function planBackendCandidates(inputs: BackendCandidateInputs): ResolvedBackend[] {
+	if (inputs.configuredPath) {
+		return [configuredBackend(inputs.configuredPath)];
 	}
 
-	// 2. Backend binary bundled in the VSIX (populated by the standalone-binary build).
-	const bundledBinary = bundledBinaryPath(context);
-	if (bundledBinary) {
-		yield { command: bundledBinary, baseArgs: [], source: `bundled backend (${bundledBinary})` };
+	const candidates: ResolvedBackend[] = [];
+	if (inputs.isDevelopment && inputs.developmentVenvPath) {
+		candidates.push({
+			command: inputs.developmentVenvPath,
+			baseArgs: PYTHON_MODULE_ARGS,
+			source: `development environment (${inputs.developmentVenvPath})`,
+			kind: 'development',
+		});
 	}
+	if (inputs.bundledBinaryPath) {
+		candidates.push({
+			command: inputs.bundledBinaryPath,
+			baseArgs: [],
+			source: `bundled backend (${inputs.bundledBinaryPath})`,
+			kind: 'bundled',
+		});
+	}
+	return candidates;
+}
 
-	// 3. Managed virtual environment provisioned into global storage.
-	const managedVenv = managedVenvPython(context);
-	if (managedVenv) {
-		yield { command: managedVenv, baseArgs: pythonBaseArgs, source: `managed environment (${managedVenv})` };
-	}
+/** Build the override candidate, treating an `mrd-viz` executable as a binary and anything else as an interpreter. */
+function configuredBackend(configuredPath: string): ResolvedBackend {
+	const baseArgs = looksLikeBackendBinary(configuredPath) ? [] : PYTHON_MODULE_ARGS;
+	return { command: configuredPath, baseArgs, source: `mrdViz.backendPath setting (${configuredPath})`, kind: 'override' };
+}
 
-	// 4. Repo virtual environment (F5 dev host / contributors).
-	const developmentVenv = developmentVenvPython(context);
-	if (developmentVenv) {
-		yield { command: developmentVenv, baseArgs: pythonBaseArgs, source: `development environment (${developmentVenv})` };
-	}
-
-	// 5. A Python interpreter on PATH.
-	for (const command of ['python', 'python3']) {
-		yield { command, baseArgs: pythonBaseArgs, source: `"${command}" on PATH` };
-	}
+/** Whether a configured path points at the standalone backend binary rather than a Python interpreter. */
+function looksLikeBackendBinary(configuredPath: string): boolean {
+	const base = path.basename(configuredPath).toLowerCase();
+	return base === 'mrd-viz' || base === 'mrd-viz.exe';
 }
 
 interface ProbeResult {
@@ -172,11 +223,6 @@ function pythonExecutableRelative(): string {
 function bundledBinaryPath(context: vscode.ExtensionContext): string | undefined {
 	const name = process.platform === 'win32' ? 'mrd-viz.exe' : 'mrd-viz';
 	const candidate = path.join(context.extensionUri.fsPath, 'media', 'backend', name);
-	return existsSync(candidate) ? candidate : undefined;
-}
-
-function managedVenvPython(context: vscode.ExtensionContext): string | undefined {
-	const candidate = managedVenvPythonPath(context);
 	return existsSync(candidate) ? candidate : undefined;
 }
 

--- a/mrd-viz/extension/mrd-viz/src/backendRunner.ts
+++ b/mrd-viz/extension/mrd-viz/src/backendRunner.ts
@@ -1,6 +1,6 @@
-import { execFile } from 'node:child_process';
-
 import { isMrdImageResponsePayload, isMrdOpenPayload, type MrdImageResponsePayload, type MrdOpenPayload } from './contracts';
+import { BACKEND_RESPONSE_MAX_BUFFER_BYTES } from './backendConstants';
+import { runProcess } from './subprocess';
 
 export interface BackendRunnerOptions {
 	command: string;
@@ -70,29 +70,16 @@ function sliceArgs(sliceCoords?: number[]): string[] {
 	return args;
 }
 
-function execBackend(command: string, commandArguments: string[], timeoutMs: number, signal?: AbortSignal): Promise<{ stdout: string; stderr: string }> {
-	return new Promise((resolve, reject) => {
-		execFile(
-			command,
-			commandArguments,
-			{
-				maxBuffer: 64 * 1024 * 1024,
-				timeout: timeoutMs,
-				windowsHide: true,
-				signal,
-			},
-			(error, stdout, stderr) => {
-				const stdoutText = stdout.toString();
-				const stderrText = stderr.toString();
-				if (error && !stdoutText.trim()) {
-					reject(new MrdVizBackendError(error.message, stdoutText, stderrText));
-					return;
-				}
-
-				resolve({ stdout: stdoutText, stderr: stderrText });
-			},
-		);
+async function execBackend(command: string, commandArguments: string[], timeoutMs: number, signal?: AbortSignal): Promise<{ stdout: string; stderr: string }> {
+	const { error, stdout, stderr } = await runProcess(command, commandArguments, {
+		timeoutMs,
+		maxBuffer: BACKEND_RESPONSE_MAX_BUFFER_BYTES,
+		signal,
 	});
+	if (error && !stdout.trim()) {
+		throw new MrdVizBackendError(error.message, stdout, stderr);
+	}
+	return { stdout, stderr };
 }
 
 function parseOpenPayload(stdout: string, stderr: string): MrdOpenPayload {

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -137,7 +137,7 @@ async function selectInterpreter(): Promise<void> {
 	const config = vscode.workspace.getConfiguration('mrdViz');
 	await config.update('backendPath', picked[0].fsPath, vscode.ConfigurationTarget.Global);
 	invalidateBackendCache();
-	void vscode.window.showInformationMessage('MRD Viz backend interpreter updated.');
+	void vscode.window.showInformationMessage('MRD Viz backend updated.');
 }
 
 /** A provisioning step that failed, tagged with the human-readable phase for clear reporting. */

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -106,12 +106,18 @@ async function pickTargetUri(resource?: vscode.Uri, selectedResources?: vscode.U
 }
 
 async function setUpBackend(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel): Promise<void> {
+	// If a managed backend is already provisioned, this rebuilds it from scratch, so confirm the
+	// reinstall rather than silently clobbering a working environment.
+	const alreadyInstalled = existsSync(managedVenvPythonPath(context));
+	const confirmLabel = alreadyInstalled ? 'Reinstall' : 'Install';
 	const proceed = await vscode.window.showInformationMessage(
-		'Set up the MRD Viz backend automatically? This creates a private Python virtual environment in the extension\u2019s storage and installs the "mrd_viz" package with pip. It needs a Python 3.12+ interpreter on PATH and network access.',
+		alreadyInstalled
+			? 'An MRD Viz backend is already installed in the extension\u2019s storage. Reinstall it? This deletes and rebuilds the private Python virtual environment and re-installs the "mrd_viz" package with pip. It needs a Python 3.12+ interpreter on PATH and network access.'
+			: 'Set up the MRD Viz backend automatically? This creates a private Python virtual environment in the extension\u2019s storage and installs the "mrd_viz" package with pip. It needs a Python 3.12+ interpreter on PATH and network access.',
 		{ modal: true },
-		'Install',
+		confirmLabel,
 	);
-	if (proceed !== 'Install') {
+	if (proceed !== confirmLabel) {
 		return;
 	}
 
@@ -123,7 +129,7 @@ async function setUpBackend(context: vscode.ExtensionContext, outputChannel: vsc
 			'backendPath', managedVenvPythonPath(context), vscode.ConfigurationTarget.Global,
 		);
 		invalidateBackendCache();
-		void vscode.window.showInformationMessage('MRD Viz backend installed.');
+		void vscode.window.showInformationMessage(alreadyInstalled ? 'MRD Viz backend reinstalled.' : 'MRD Viz backend installed.');
 	}
 }
 

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('mrd-viz.setUpBackend', () => setUpBackend(context, outputChannel)),
 		vscode.commands.registerCommand('mrd-viz.selectInterpreter', () => selectInterpreter()),
 		vscode.workspace.onDidChangeConfiguration(event => {
-			if (event.affectsConfiguration('mrdViz.backendPath') || event.affectsConfiguration('mrdViz.pythonPath')) {
+			if (event.affectsConfiguration('mrdViz.backendPath')) {
 				invalidateBackendCache();
 			}
 		}),

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -1,11 +1,18 @@
-import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { mkdir, rename, rm } from 'node:fs/promises';
 import * as path from 'node:path';
 import * as vscode from 'vscode';
 
+import {
+	PROVISIONING_LOG_MAX_BUFFER_BYTES,
+	PROVISIONING_PYTHON_CANDIDATES,
+	PROVISIONING_STEP_TIMEOUT_MS,
+	PYPI_PACKAGE_NAME,
+	PYTHON_VERSION_PROBE_TIMEOUT_MS,
+} from './backendConstants';
 import { invalidateBackendCache, managedVenvDirectory, managedVenvPythonPath } from './backendResolver';
 import { MrdEditorProvider, MRD_VIEW_TYPE } from './mrdEditorProvider';
+import { runProcess } from './subprocess';
 
 export function activate(context: vscode.ExtensionContext) {
 	const outputChannel = vscode.window.createOutputChannel('MRD Viz');
@@ -148,6 +155,9 @@ class BackendSetupError extends Error {
 	}
 }
 
+/** Flags applied to every pip call: silence the version-check notice and never block on a prompt. */
+const PIP_FLAGS = ['--disable-pip-version-check', '--no-input'];
+
 /**
  * Provision the managed backend virtual environment in global storage: create a venv from a
  * discovered Python 3.12+ interpreter and `pip install` the backend. The caller persists the venv
@@ -167,7 +177,7 @@ async function provisionManagedBackend(context: vscode.ExtensionContext, outputC
 
 	const venvDir = managedVenvDirectory(context);
 	const venvPython = managedVenvPythonPath(context);
-	const installTarget = repoBackendInstallTarget(context) ?? 'mrd-viz';
+	const installTarget = repoBackendInstallTarget(context) ?? PYPI_PACKAGE_NAME;
 
 	return vscode.window.withProgress(
 		{ location: vscode.ProgressLocation.Notification, title: 'Setting up MRD Viz backend', cancellable: false },
@@ -179,12 +189,15 @@ async function provisionManagedBackend(context: vscode.ExtensionContext, outputC
 				await runProvisioningStep('creating the virtual environment', basePython, ['-m', 'venv', venvDir], outputChannel);
 
 				progress.report({ message: 'Upgrading pip\u2026' });
-				await runProvisioningStep('upgrading pip', venvPython, ['-m', 'pip', 'install', '--upgrade', 'pip'], outputChannel);
+				await runProvisioningStep('upgrading pip', venvPython, ['-m', 'pip', 'install', ...PIP_FLAGS, '--upgrade', 'pip'], outputChannel);
 
 				progress.report({ message: 'Installing the mrd_viz backend\u2026' });
-				const installArgs = installTarget === 'mrd-viz'
-					? ['-m', 'pip', 'install', 'mrd-viz']
-					: ['-m', 'pip', 'install', '-e', installTarget];
+				// TODO(publish-pypi): the PYPI_PACKAGE_NAME branch only resolves once the backend is
+				// published to PyPI; until then setup succeeds only from a repo checkout (editable
+				// install) and otherwise fails loudly with the package-not-found hint.
+				const installArgs = installTarget === PYPI_PACKAGE_NAME
+					? ['-m', 'pip', 'install', ...PIP_FLAGS, PYPI_PACKAGE_NAME]
+					: ['-m', 'pip', 'install', ...PIP_FLAGS, '-e', installTarget];
 				await runProvisioningStep('installing the mrd_viz backend', venvPython, installArgs, outputChannel);
 
 				return true;
@@ -276,7 +289,7 @@ export function classifyProvisioningFailure(detail: string): string {
 
 /** Locate a Python 3.12+ interpreter on PATH suitable for building the backend venv. */
 async function findProvisioningPython(): Promise<string | undefined> {
-	for (const command of ['python3.12', 'python3', 'python']) {
+	for (const command of PROVISIONING_PYTHON_CANDIDATES) {
 		if (await isPython312OrNewer(command)) {
 			return command;
 		}
@@ -284,27 +297,21 @@ async function findProvisioningPython(): Promise<string | undefined> {
 	return undefined;
 }
 
-function isPython312OrNewer(command: string): Promise<boolean> {
-	return new Promise(resolve => {
-		execFile(
-			command,
-			['-c', 'import sys; print(sys.version_info[0], sys.version_info[1])'],
-			{ timeout: 10000, windowsHide: true },
-			(error, stdout) => {
-				if (error) {
-					resolve(false);
-					return;
-				}
-				const match = /^(\d+)\s+(\d+)/.exec(stdout.trim());
-				if (!match) {
-					resolve(false);
-					return;
-				}
-				const [major, minor] = [Number(match[1]), Number(match[2])];
-				resolve(major === 3 && minor >= 12);
-			},
-		);
-	});
+async function isPython312OrNewer(command: string): Promise<boolean> {
+	const { error, stdout } = await runProcess(
+		command,
+		['-c', 'import sys; print(sys.version_info[0], sys.version_info[1])'],
+		{ timeoutMs: PYTHON_VERSION_PROBE_TIMEOUT_MS },
+	);
+	if (error) {
+		return false;
+	}
+	const match = /^(\d+)\s+(\d+)/.exec(stdout.trim());
+	if (!match) {
+		return false;
+	}
+	const [major, minor] = [Number(match[1]), Number(match[2])];
+	return major === 3 && minor >= 12;
 }
 
 /** When running from the repo checkout, prefer an editable install of the local backend. */
@@ -313,20 +320,18 @@ function repoBackendInstallTarget(context: vscode.ExtensionContext): string | un
 	return existsSync(path.join(backendDir, 'pyproject.toml')) ? backendDir : undefined;
 }
 
-function runProvisioningStep(step: string, command: string, args: string[], outputChannel: vscode.OutputChannel): Promise<void> {
+async function runProvisioningStep(step: string, command: string, args: string[], outputChannel: vscode.OutputChannel): Promise<void> {
 	outputChannel.appendLine(`Running: ${command} ${args.join(' ')}`);
-	return new Promise((resolve, reject) => {
-		execFile(command, args, { timeout: 600000, windowsHide: true, maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
-			appendIfPresent(outputChannel, 'stdout', stdout);
-			appendIfPresent(outputChannel, 'stderr', stderr);
-			if (error) {
-				const detail = (stderr.trim().split(/\r?\n/).pop() || error.message).trim();
-				reject(new BackendSetupError(step, detail));
-				return;
-			}
-			resolve();
-		});
+	const { error, stdout, stderr } = await runProcess(command, args, {
+		timeoutMs: PROVISIONING_STEP_TIMEOUT_MS,
+		maxBuffer: PROVISIONING_LOG_MAX_BUFFER_BYTES,
 	});
+	appendIfPresent(outputChannel, 'stdout', stdout);
+	appendIfPresent(outputChannel, 'stderr', stderr);
+	if (error) {
+		const detail = (stderr.trim().split(/\r?\n/).pop() || error.message).trim();
+		throw new BackendSetupError(step, detail);
+	}
 }
 
 function appendIfPresent(outputChannel: vscode.OutputChannel, label: string, text: string): void {

--- a/mrd-viz/extension/mrd-viz/src/extension.ts
+++ b/mrd-viz/extension/mrd-viz/src/extension.ts
@@ -22,7 +22,7 @@ export function activate(context: vscode.ExtensionContext) {
 		vscode.commands.registerCommand('mrd-viz.setUpBackend', () => setUpBackend(context, outputChannel)),
 		vscode.commands.registerCommand('mrd-viz.selectInterpreter', () => selectInterpreter()),
 		vscode.workspace.onDidChangeConfiguration(event => {
-			if (event.affectsConfiguration('mrdViz.pythonPath')) {
+			if (event.affectsConfiguration('mrdViz.backendPath') || event.affectsConfiguration('mrdViz.pythonPath')) {
 				invalidateBackendCache();
 			}
 		}),
@@ -110,6 +110,11 @@ async function setUpBackend(context: vscode.ExtensionContext, outputChannel: vsc
 
 	const installed = await provisionManagedBackend(context, outputChannel);
 	if (installed) {
+		// Persist the managed venv as the configured backend (machine-scoped) so it becomes a
+		// first-class override the resolver reads directly, rather than an implicit candidate.
+		await vscode.workspace.getConfiguration('mrdViz').update(
+			'backendPath', managedVenvPythonPath(context), vscode.ConfigurationTarget.Global,
+		);
 		invalidateBackendCache();
 		void vscode.window.showInformationMessage('MRD Viz backend installed.');
 	}
@@ -126,19 +131,13 @@ async function selectInterpreter(): Promise<void> {
 		return;
 	}
 
+	// backendPath is machine-scoped, so this writes to the context-appropriate machine settings
+	// (host user settings, or the dev container's remote settings) and cannot leak across that
+	// boundary or be committed to a workspace — no narrower-scope clearing needed.
 	const config = vscode.workspace.getConfiguration('mrdViz');
-	await config.update('pythonPath', picked[0].fsPath, vscode.ConfigurationTarget.Global);
-	// Clear any narrower-scoped values (e.g. a dev container's workspace-level setting) that would
-	// otherwise shadow the interpreter the user just picked and block recovery via the guided flow.
-	const inspected = config.inspect<string>('pythonPath');
-	if (inspected?.workspaceFolderValue !== undefined) {
-		await config.update('pythonPath', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
-	}
-	if (inspected?.workspaceValue !== undefined) {
-		await config.update('pythonPath', undefined, vscode.ConfigurationTarget.Workspace);
-	}
+	await config.update('backendPath', picked[0].fsPath, vscode.ConfigurationTarget.Global);
 	invalidateBackendCache();
-	void vscode.window.showInformationMessage('MRD Viz Python interpreter updated.');
+	void vscode.window.showInformationMessage('MRD Viz backend interpreter updated.');
 }
 
 /** A provisioning step that failed, tagged with the human-readable phase for clear reporting. */
@@ -150,11 +149,12 @@ class BackendSetupError extends Error {
 }
 
 /**
- * Provision the managed backend virtual environment (resolver candidate #3) in global storage:
- * create a venv from a discovered Python 3.12+ interpreter and `pip install` the backend. Returns
- * true only if every step succeeds; on any failure the half-provisioned venv is removed (so a
- * stale interpreter can't satisfy the resolver probe and then fail at `import mrd_viz`) and the
- * cause is surfaced to the user and the output channel.
+ * Provision the managed backend virtual environment in global storage: create a venv from a
+ * discovered Python 3.12+ interpreter and `pip install` the backend. The caller persists the venv
+ * interpreter to `mrdViz.backendPath` on success. Returns true only if every step succeeds; on any
+ * failure the half-provisioned venv is removed (so a stale interpreter can't satisfy the resolver
+ * probe and then fail at `import mrd_viz`) and the cause is surfaced to the user and the output
+ * channel.
  */
 async function provisionManagedBackend(context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel): Promise<boolean> {
 	const basePython = await findProvisioningPython();

--- a/mrd-viz/extension/mrd-viz/src/mrdEditorProvider.ts
+++ b/mrd-viz/extension/mrd-viz/src/mrdEditorProvider.ts
@@ -2,6 +2,7 @@ import * as path from 'node:path';
 import * as vscode from 'vscode';
 
 import { MrdVizBackendError, runOpenFile, type BackendRunnerOptions } from './backendRunner';
+import { BACKEND_TIMEOUT_MS_DEFAULT } from './backendConstants';
 import { invalidateBackendCache, resolveBackend } from './backendResolver';
 import { redactingPayloadReplacer } from './contracts';
 import { getMrdBackendMissingHtml, getMrdViewerHtml } from './webviewHtml';
@@ -59,7 +60,7 @@ export class MrdEditorProvider implements vscode.CustomReadonlyEditorProvider<Mr
 		webviewPanel.webview.html = getMrdLoadingHtml(webviewPanel.webview, document.uri);
 
 		const configuration = vscode.workspace.getConfiguration('mrdViz');
-		const timeoutMs = configuration.get<number>('backendTimeoutMs') ?? 30000;
+		const timeoutMs = configuration.get<number>('backendTimeoutMs') ?? BACKEND_TIMEOUT_MS_DEFAULT;
 		const maxThumbnails = configuration.get<number>('maxThumbnails') ?? 128;
 
 		const resolution = await resolveBackend(this.context, timeoutMs);

--- a/mrd-viz/extension/mrd-viz/src/subprocess.ts
+++ b/mrd-viz/extension/mrd-viz/src/subprocess.ts
@@ -1,0 +1,35 @@
+import { execFile, type ExecFileException } from 'node:child_process';
+
+/** Options for {@link runProcess}. Each caller sets the timeout/buffer that suits its workload. */
+export interface RunProcessOptions {
+	timeoutMs: number;
+	/** Max stdout/stderr bytes; omit to use Node's default. */
+	maxBuffer?: number;
+	/** Abort signal to cancel an in-flight process. */
+	signal?: AbortSignal;
+}
+
+/** Result of a finished process: its captured output plus any spawn/exit error. */
+export interface ProcessOutcome {
+	error?: ExecFileException;
+	stdout: string;
+	stderr: string;
+}
+
+/**
+ * Thin wrapper over `execFile` for short-lived subprocesses: it standardizes the option plumbing
+ * (timeout, buffer, `windowsHide`, abort signal) and resolves with `{ error, stdout, stderr }` so
+ * each caller keeps its own error shaping rather than sharing one policy.
+ */
+export function runProcess(command: string, args: string[], options: RunProcessOptions): Promise<ProcessOutcome> {
+	return new Promise(resolve => {
+		execFile(
+			command,
+			args,
+			{ timeout: options.timeoutMs, maxBuffer: options.maxBuffer, windowsHide: true, signal: options.signal },
+			(error, stdout, stderr) => {
+				resolve({ error: error ?? undefined, stdout: stdout.toString(), stderr: stderr.toString() });
+			},
+		);
+	});
+}

--- a/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
+++ b/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 
 import { classifyProvisioningFailure, getOpenWithMrdEditorArgs, removeIncompleteVenv } from '../extension';
 import { MRD_VIEW_TYPE } from '../mrdEditorProvider';
+import { planBackendCandidates } from '../backendResolver';
 import { getMrdBackendMissingHtml } from '../webviewHtml';
 import { getMrdErrorHtml } from '../stateHtml';
 import { isViewerToExtensionMessage } from '../contracts';
@@ -99,6 +100,18 @@ suite('MRD Viz Extension', () => {
 		assert.ok(html.includes('mrd-viz.selectInterpreter'));
 	});
 
+	test('tailors the backend-missing view when a developer override is broken', () => {
+		const webview = { cspSource: 'vscode-resource:' } as vscode.Webview;
+		const html = getMrdBackendMissingHtml(webview, [
+			{ source: 'mrdViz.backendPath setting (/x/python)', kind: 'override', detail: "No module named 'mrd_viz'" },
+		]);
+
+		// The override wording leads instead of the bundled-backend wording.
+		assert.ok(html.includes('configured in'));
+		assert.ok(html.includes('mrdViz.backendPath'));
+		assert.ok(!html.includes('could not run its bundled backend'));
+	});
+
 	test('validates loadImage messages including optional slice coordinates', () => {
 		assert.ok(isViewerToExtensionMessage({ type: 'loadImage', requestId: '1', imageIndex: 0 }));
 		assert.ok(isViewerToExtensionMessage({ type: 'loadImage', requestId: '1', imageIndex: 2, sliceCoords: [0, 1] }));
@@ -148,6 +161,56 @@ suite('MRD Viz backend provisioning', () => {
 
 		assert.ok(!existsSync(missing));
 		assert.ok(messages.some(message => message.includes('Cleaned up incomplete backend environment')));
+	});
+});
+
+suite('MRD Viz backend resolution order', () => {
+	const bundled = '/ext/media/backend/mrd-viz';
+	const devVenv = '/repo/backend/.venv/bin/python';
+
+	test('a configured override is the only candidate (no silent fallback to the bundled binary)', () => {
+		const candidates = planBackendCandidates({
+			configuredPath: '/custom/bin/python',
+			bundledBinaryPath: bundled,
+			developmentVenvPath: devVenv,
+			isDevelopment: true,
+		});
+
+		assert.strictEqual(candidates.length, 1);
+		assert.strictEqual(candidates[0].kind, 'override');
+		assert.strictEqual(candidates[0].command, '/custom/bin/python');
+		assert.deepStrictEqual(candidates[0].baseArgs, ['-m', 'mrd_viz.cli']);
+	});
+
+	test('an override pointing at the mrd-viz binary runs as a binary (no python -m args)', () => {
+		const [candidate] = planBackendCandidates({ configuredPath: '/opt/mrd-viz', isDevelopment: false });
+
+		assert.strictEqual(candidate.kind, 'override');
+		assert.deepStrictEqual(candidate.baseArgs, []);
+	});
+
+	test('an unconfigured production install uses only the bundled binary', () => {
+		const candidates = planBackendCandidates({
+			bundledBinaryPath: bundled,
+			developmentVenvPath: devVenv,
+			isDevelopment: false,
+		});
+
+		assert.deepStrictEqual(candidates.map(candidate => candidate.kind), ['bundled']);
+	});
+
+	test('the development host tries the repo venv before the bundled binary', () => {
+		const candidates = planBackendCandidates({
+			bundledBinaryPath: bundled,
+			developmentVenvPath: devVenv,
+			isDevelopment: true,
+		});
+
+		assert.deepStrictEqual(candidates.map(candidate => candidate.kind), ['development', 'bundled']);
+	});
+
+	test('yields no candidates when nothing is configured, bundled, or available', () => {
+		assert.deepStrictEqual(planBackendCandidates({ isDevelopment: false }), []);
 	});
 });
 

--- a/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
+++ b/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
@@ -112,6 +112,18 @@ suite('MRD Viz Extension', () => {
 		assert.ok(!html.includes('could not run its bundled backend'));
 	});
 
+	test('names the legacy setting on the backend-missing page when the override came from pythonPath', () => {
+		const webview = { cspSource: 'vscode-resource:' } as vscode.Webview;
+		const html = getMrdBackendMissingHtml(webview, [
+			{ source: 'mrdViz.pythonPath setting (/x/python)', kind: 'override', settingKey: 'mrdViz.pythonPath', detail: 'boom' },
+		]);
+
+		assert.ok(html.includes('configured in'));
+		assert.ok(html.includes('mrdViz.pythonPath'));
+		// The intro must not claim the value came from backendPath when it came from the legacy setting.
+		assert.ok(!html.includes('<code>mrdViz.backendPath</code> could not be run'));
+	});
+
 	test('validates loadImage messages including optional slice coordinates', () => {
 		assert.ok(isViewerToExtensionMessage({ type: 'loadImage', requestId: '1', imageIndex: 0 }));
 		assert.ok(isViewerToExtensionMessage({ type: 'loadImage', requestId: '1', imageIndex: 2, sliceCoords: [0, 1] }));
@@ -180,6 +192,18 @@ suite('MRD Viz backend resolution order', () => {
 		assert.strictEqual(candidates[0].kind, 'override');
 		assert.strictEqual(candidates[0].command, '/custom/bin/python');
 		assert.deepStrictEqual(candidates[0].baseArgs, ['-m', 'mrd_viz.cli']);
+	});
+
+	test('labels the override source with the legacy setting when it came from mrdViz.pythonPath', () => {
+		const [candidate] = planBackendCandidates({
+			configuredPath: '/legacy/bin/python',
+			configuredSettingKey: 'mrdViz.pythonPath',
+			isDevelopment: false,
+		});
+
+		assert.strictEqual(candidate.kind, 'override');
+		assert.strictEqual(candidate.settingKey, 'mrdViz.pythonPath');
+		assert.ok(candidate.source.includes('mrdViz.pythonPath'));
 	});
 
 	test('an override pointing at the mrd-viz binary runs as a binary (no python -m args)', () => {

--- a/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
+++ b/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
@@ -111,18 +111,6 @@ suite('MRD Viz Extension', () => {
 		assert.ok(!html.includes('could not run its bundled backend'));
 	});
 
-	test('names the legacy setting on the backend-missing page when the override came from pythonPath', () => {
-		const webview = { cspSource: 'vscode-resource:' } as vscode.Webview;
-		const html = getMrdBackendMissingHtml(webview, [
-			{ source: 'mrdViz.pythonPath setting (/x/python)', kind: 'override', settingKey: 'mrdViz.pythonPath', detail: 'boom' },
-		]);
-
-		assert.ok(html.includes('configured in'));
-		assert.ok(html.includes('mrdViz.pythonPath'));
-		// The intro must not claim the value came from backendPath when it came from the legacy setting.
-		assert.ok(!html.includes('<code>mrdViz.backendPath</code> could not be run'));
-	});
-
 	test('validates loadImage messages including optional slice coordinates', () => {
 		assert.ok(isViewerToExtensionMessage({ type: 'loadImage', requestId: '1', imageIndex: 0 }));
 		assert.ok(isViewerToExtensionMessage({ type: 'loadImage', requestId: '1', imageIndex: 2, sliceCoords: [0, 1] }));
@@ -191,18 +179,6 @@ suite('MRD Viz backend resolution order', () => {
 		assert.strictEqual(candidates[0].kind, 'override');
 		assert.strictEqual(candidates[0].command, '/custom/bin/python');
 		assert.deepStrictEqual(candidates[0].baseArgs, ['-m', 'mrd_viz.cli']);
-	});
-
-	test('labels the override source with the legacy setting when it came from mrdViz.pythonPath', () => {
-		const [candidate] = planBackendCandidates({
-			configuredPath: '/legacy/bin/python',
-			configuredSettingKey: 'mrdViz.pythonPath',
-			isDevelopment: false,
-		});
-
-		assert.strictEqual(candidate.kind, 'override');
-		assert.strictEqual(candidate.settingKey, 'mrdViz.pythonPath');
-		assert.ok(candidate.source.includes('mrdViz.pythonPath'));
 	});
 
 	test('an override pointing at the mrd-viz binary runs as a binary (no python -m args)', () => {

--- a/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
+++ b/mrd-viz/extension/mrd-viz/src/test/extension.test.ts
@@ -84,18 +84,17 @@ suite('MRD Viz Extension', () => {
 	test('renders a guided backend-missing view with escaped candidates and failure reasons', () => {
 		const webview = { cspSource: 'vscode-resource:' } as vscode.Webview;
 		const html = getMrdBackendMissingHtml(webview, [
-			{ source: 'bundled backend (/x/mrd-viz)', detail: "libm.so.6: version `GLIBC_2.38' not found" },
-			{ source: 'mrdViz.pythonPath setting (<x>)', detail: "No module named 'mrd_viz'" },
-			{ source: '"python" on PATH' },
+			{ source: 'development environment (<x>)', kind: 'development', detail: "No module named 'mrd_viz'" },
+			{ source: 'bundled backend (/x/mrd-viz)', kind: 'bundled', detail: "libm.so.6: version `GLIBC_2.38' not found" },
 		]);
 
 		assert.ok(html.includes('MRD Viz backend not found'));
 		assert.ok(html.includes('bundled backend (/x/mrd-viz)'));
-		assert.ok(html.includes('mrdViz.pythonPath setting (&lt;x&gt;)'));
+		// Candidate sources are HTML-escaped.
+		assert.ok(html.includes('development environment (&lt;x&gt;)'));
 		// The captured probe stderr (e.g. the glibc mismatch) is surfaced and escaped.
 		assert.ok(html.includes('GLIBC_2.38'));
 		assert.ok(html.includes('No module named &#39;mrd_viz&#39;') || html.includes("No module named 'mrd_viz'"));
-		assert.ok(html.includes('No diagnostic output was captured.'));
 		assert.ok(html.includes('mrd-viz.setUpBackend'));
 		assert.ok(html.includes('mrd-viz.selectInterpreter'));
 	});

--- a/mrd-viz/extension/mrd-viz/src/webviewHtml.ts
+++ b/mrd-viz/extension/mrd-viz/src/webviewHtml.ts
@@ -13,6 +13,14 @@ const MAX_IMAGE_CACHE_ENTRIES = 32;
 export function getMrdBackendMissingHtml(webview: vscode.Webview, tried: BackendAttempt[]): string {
 	const nonce = getNonce();
 	const cspSource = webview.cspSource;
+	// A broken developer override (mrdViz.backendPath) is a different problem from an end-user install
+	// whose bundled backend won't run, so lead with the relevant explanation and primary action.
+	const developerOverride = tried.some(attempt => attempt.kind === 'override');
+	const intro = developerOverride
+		? 'The backend configured in <code>mrdViz.backendPath</code> could not be run. It was probed with <code>--version</code> and failed for the reason shown:'
+		: 'MRD Viz could not run its bundled backend on this platform. Each candidate below was probed with <code>--version</code> and failed for the reason shown:';
+	const selectClass = developerOverride ? '' : 'secondary';
+	const setupClass = developerOverride ? 'secondary' : '';
 	const triedItems = tried.map(attempt => {
 		const source = `<span class="candidate">${escapeHtml(attempt.source)}</span>`;
 		const detail = attempt.detail
@@ -90,22 +98,22 @@ export function getMrdBackendMissingHtml(webview: vscode.Webview, tried: Backend
 <body>
 	<main>
 		<h1>MRD Viz backend not found</h1>
-		<p>MRD Viz needs a Python 3.12+ environment with the <code>mrd_viz</code> package installed, or the bundled standalone backend. Each candidate below was probed with <code>--version</code> and failed for the reason shown:</p>
+		<p>${intro}</p>
 		<ul class="candidates">${triedItems}</ul>
 
 		<div class="actions">
-			<button type="button" id="select">Select Python Interpreter…</button>
-			<button type="button" id="setup" class="secondary">Set Up Backend Automatically…</button>
+			<button type="button" id="select" class="${selectClass}">Select Python Interpreter…</button>
+			<button type="button" id="setup" class="${setupClass}">Set Up Backend Automatically…</button>
 		</div>
 
 		<h2>Point MRD Viz at a Python environment</h2>
-		<p>Create an environment that has the <code>mrd_viz</code> package, then set <code>mrdViz.pythonPath</code> to its interpreter:</p>
+		<p>Create an environment that has the <code>mrd_viz</code> package, then set <code>mrdViz.backendPath</code> to its interpreter (or to a prebuilt <code>mrd-viz</code> binary):</p>
 		<pre class="setup">python3 -m venv ~/.mrd-viz-venv
 ~/.mrd-viz-venv/bin/pip install mrd-viz   # or, from a checkout: pip install -e path/to/mrd/mrd-viz/backend
 
-# then set mrdViz.pythonPath to:
+# then set mrdViz.backendPath to:
 ~/.mrd-viz-venv/bin/python</pre>
-		<p>Use <b>Select Python Interpreter…</b> above to browse to that interpreter (it writes <code>mrdViz.pythonPath</code> for you). The viewer reloads automatically once a working backend is found.</p>
+		<p>Use <b>Select Python Interpreter…</b> above to browse to that interpreter (it writes <code>mrdViz.backendPath</code> for you), or <b>Set Up Backend Automatically…</b> to build a managed environment. The viewer reloads automatically once a working backend is found.</p>
 		<p>You can also open this workspace in the MRD Viz dev container, which provisions the backend for you.</p>
 	</main>
 	<script nonce="${nonce}">

--- a/mrd-viz/extension/mrd-viz/src/webviewHtml.ts
+++ b/mrd-viz/extension/mrd-viz/src/webviewHtml.ts
@@ -13,11 +13,14 @@ const MAX_IMAGE_CACHE_ENTRIES = 32;
 export function getMrdBackendMissingHtml(webview: vscode.Webview, tried: BackendAttempt[]): string {
 	const nonce = getNonce();
 	const cspSource = webview.cspSource;
-	// A broken developer override (mrdViz.backendPath) is a different problem from an end-user install
-	// whose bundled backend won't run, so lead with the relevant explanation and primary action.
-	const developerOverride = tried.some(attempt => attempt.kind === 'override');
+	// A broken developer override is a different problem from an end-user install whose bundled
+	// backend won't run, so lead with the relevant explanation and primary action. The override may
+	// have come from either setting, so name the one that actually supplied the path.
+	const overrideAttempt = tried.find(attempt => attempt.kind === 'override');
+	const developerOverride = overrideAttempt !== undefined;
+	const overrideSetting = escapeHtml(overrideAttempt?.settingKey ?? 'mrdViz.backendPath');
 	const intro = developerOverride
-		? 'The backend configured in <code>mrdViz.backendPath</code> could not be run. It was probed with <code>--version</code> and failed for the reason shown:'
+		? `The backend configured in <code>${overrideSetting}</code> could not be run. It was probed with <code>--version</code> and failed for the reason shown:`
 		: 'MRD Viz could not run its bundled backend on this platform. Each candidate below was probed with <code>--version</code> and failed for the reason shown:';
 	const selectClass = developerOverride ? '' : 'secondary';
 	const setupClass = developerOverride ? 'secondary' : '';
@@ -109,7 +112,8 @@ export function getMrdBackendMissingHtml(webview: vscode.Webview, tried: Backend
 		<h2>Point MRD Viz at a Python environment</h2>
 		<p>Create an environment that has the <code>mrd_viz</code> package, then set <code>mrdViz.backendPath</code> to its interpreter (or to a prebuilt <code>mrd-viz</code> binary):</p>
 		<pre class="setup">python3 -m venv ~/.mrd-viz-venv
-~/.mrd-viz-venv/bin/pip install mrd-viz   # or, from a checkout: pip install -e path/to/mrd/mrd-viz/backend
+# install the backend from your mrd checkout (mrd-viz is not published to PyPI):
+~/.mrd-viz-venv/bin/pip install -e path/to/mrd/mrd-viz/backend
 
 # then set mrdViz.backendPath to:
 ~/.mrd-viz-venv/bin/python</pre>

--- a/mrd-viz/extension/mrd-viz/src/webviewHtml.ts
+++ b/mrd-viz/extension/mrd-viz/src/webviewHtml.ts
@@ -14,13 +14,11 @@ export function getMrdBackendMissingHtml(webview: vscode.Webview, tried: Backend
 	const nonce = getNonce();
 	const cspSource = webview.cspSource;
 	// A broken developer override is a different problem from an end-user install whose bundled
-	// backend won't run, so lead with the relevant explanation and primary action. The override may
-	// have come from either setting, so name the one that actually supplied the path.
+	// backend won't run, so lead with the relevant explanation and primary action.
 	const overrideAttempt = tried.find(attempt => attempt.kind === 'override');
 	const developerOverride = overrideAttempt !== undefined;
-	const overrideSetting = escapeHtml(overrideAttempt?.settingKey ?? 'mrdViz.backendPath');
 	const intro = developerOverride
-		? `The backend configured in <code>${overrideSetting}</code> could not be run. It was probed with <code>--version</code> and failed for the reason shown:`
+		? 'The backend configured in <code>mrdViz.backendPath</code> could not be run. It was probed with <code>--version</code> and failed for the reason shown:'
 		: 'MRD Viz could not run its bundled backend on this platform. Each candidate below was probed with <code>--version</code> and failed for the reason shown:';
 	const selectClass = developerOverride ? '' : 'secondary';
 	const setupClass = developerOverride ? 'secondary' : '';

--- a/mrd-viz/justfile
+++ b/mrd-viz/justfile
@@ -31,6 +31,9 @@
 container-setup:
     #!/usr/bin/env bash
     set -euo pipefail
+    # Point pip and npm at the first reachable index (internal mirror, else public).
+    # shellcheck source=../.devcontainer/mrd-viz/select-pkg-index.sh
+    source ../.devcontainer/mrd-viz/select-pkg-index.sh
     venv="$HOME/.venvs/mrd-viz"
     echo ">> Creating backend virtualenv: $venv"
     python -m venv "$venv"


### PR DESCRIPTION
﻿Replaces the 5-candidate backend search with deterministic two-tier resolution.

## Why
The old resolver probed 5 candidates in a fixed order (override -> bundled -> managed venv -> repo .venv -> python on PATH), silently using whatever answered. That produced the "which Python is actually used?" confusion and let a broken candidate be picked and fail late. Design: docs/BACKEND_INSTALL_MODES.md.

## What
- **Two tiers, no silent fallback:** if `mrdViz.backendPath` is set it is the only candidate (fail loud if broken); otherwise use the bundled binary. The repo `backend/.venv` is tried first only in the F5 Development host.
- **New `mrdViz.backendPath`** (interpreter or binary), **machine-scoped** so a path can't be committed to a workspace or synced across machines - this structurally prevents the host-path-leaks-into-container `ENOENT` bug. `mrdViz.pythonPath` is deprecated but still honored when explicitly set.
- **Setup/select persist** the interpreter to `backendPath`, so the managed venv is a first-class override rather than an implicit candidate.
- **Tailored backend-missing page:** distinguishes a broken override from a bundled backend that won't run.

## Notes
- Not included: the old-glibc Linux binary (tracked separately as an odin dependency); until then, unsupported platforms hit the fail-loud recovery path.
- Tests: `planBackendCandidates` ordering/no-fallback/binary-classification + the tailored page. All 18 pass; compile + lint clean.
